### PR TITLE
updated export name to task name for net

### DIFF
--- a/src/tasks/network/listProcessesUsingPort.js
+++ b/src/tasks/network/listProcessesUsingPort.js
@@ -23,7 +23,7 @@ const list = async args => {
 }
 
 module.exports = {
-  'listProcessesUsingPort': {
+  list: {
     name: 'list',
     alias: [ 'ls', 'l', ],
     action: list,


### PR DESCRIPTION
## Context
*  when printing out the keg network -h , it prints list  twice
* because the key name of the export does not match the name of the task

## Goal

*  Change the key name of the export object

## Updates

* updated the key name

## Testing

* `keg net -h` should only print out `list` once
