### PR TITLE
Ability to print option details

### DIFF
--- a/src/libs/logger/showHelp.js
+++ b/src/libs/logger/showHelp.js
@@ -179,7 +179,7 @@ const showTaskOptionDetail = (task, option, infoSpacer, dblSpacer) => {
   }
 
   // if no key found, default to showing all options
-  return showTaskOptions(task, infoSpacer, dblSpacer)
+  showTaskOptions(task, infoSpacer, dblSpacer)
 
 }
 

--- a/src/libs/logger/showHelp.js
+++ b/src/libs/logger/showHelp.js
@@ -1,4 +1,4 @@
-const { get, isStr, isObj, mapObj } = require('jsutils')
+const { get, isStr, isObj, mapObj, isArr } = require('jsutils')
 const { Logger } = require('./logger')
 const colors = require('colors/safe')
 
@@ -152,6 +152,36 @@ const showAllHelp = (tasks, opts={}) => {
   Logger.empty()
 }
 
+/**
+ * Displays the detail info (if any) of a specific option from a task (alias, description, example)
+ * @example keg core start --attached -h
+ * @param {Object} task 
+ * @param {string} option - option item from the task
+ * @param {string} infoSpacer - spacing
+ * @param {string} dblSpacer - spacing
+ */
+const showTaskOptionDetail = (task, option, infoSpacer, dblSpacer) => {
+
+  if(!task.options) return
+
+  let validKey
+  // 1. find matching option key in task
+  mapObj(task.options, (key) => {
+    if (option.includes(key)) {
+      return validKey = key
+    }
+  })
+  // 2. if found, display the info 
+  if (validKey) {
+    Logger.empty()
+    console.log(colors.brightBlue(`${infoSpacer}Option: ${validKey}`))
+    return showTaskInfo(task.options[validKey], `  ${infoSpacer}`)
+  }
+
+  // if no key found, default to showing all options
+  return showTaskOptions(task, infoSpacer, dblSpacer)
+
+}
 
 /**
  * Prints information about a single task 
@@ -170,7 +200,12 @@ const showTaskHelp = (task, opts={}) => {
   showHelpHeader(header)
   showTaskHeader(task.name, header, spacer, dblSpacer)
   showTaskInfo(task, infoSpacer)
-  showTaskOptions(task, infoSpacer, dblSpacer)
+
+  // if opt is array, then we passed in an option to the help cmd
+  isArr(opts) && opts.length > 1
+    ? showTaskOptionDetail(task, opts[0], infoSpacer, dblSpacer)
+    : showTaskOptions(task, infoSpacer, dblSpacer)
+  
 
   subtasks && showSubTasks(task, { ...opts, dblSpacer })
 }

--- a/src/tasks/core/start.js
+++ b/src/tasks/core/start.js
@@ -70,12 +70,12 @@ module.exports = {
       },
       cache: {
         description: 'Docker will use build cache when building the image',
-        example: 'keg core --cache false',
+        example: 'keg core start --cache false',
         default: true
       },
       clean: {
         description: 'Cleans docker-sync before running the keg-core',
-        example: 'keg core --clean true',
+        example: 'keg core start --clean true',
         default: false
       },
       command: {
@@ -93,12 +93,12 @@ module.exports = {
       docker: {
         alias: [ 'doc' ],
         description: `Extra docker arguments to pass to the 'docker run command'`,
-        example: 'keg core --docker "-e MY_EXTRA_ENV=foo"'
+        example: 'keg core start --docker "-e MY_EXTRA_ENV=foo"'
       },
       env: {
         alias: [ 'environment' ],
         description: 'Environment to start the Docker service in',
-        example: 'keg core --env staging',
+        example: 'keg core start --env staging',
         default: 'development',
       },
       ensure: {

--- a/src/tasks/core/start.js
+++ b/src/tasks/core/start.js
@@ -70,12 +70,12 @@ module.exports = {
       },
       cache: {
         description: 'Docker will use build cache when building the image',
-        example: 'keg core start --cache false',
+        example: 'keg core --cache false',
         default: true
       },
       clean: {
         description: 'Cleans docker-sync before running the keg-core',
-        example: 'keg core start --clean true',
+        example: 'keg core --clean true',
         default: false
       },
       command: {
@@ -93,12 +93,12 @@ module.exports = {
       docker: {
         alias: [ 'doc' ],
         description: `Extra docker arguments to pass to the 'docker run command'`,
-        example: 'keg core start --docker "-e MY_EXTRA_ENV=foo"'
+        example: 'keg core --docker "-e MY_EXTRA_ENV=foo"'
       },
       env: {
         alias: [ 'environment' ],
         description: 'Environment to start the Docker service in',
-        example: 'keg core start --env staging',
+        example: 'keg core --env staging',
         default: 'development',
       },
       ensure: {


### PR DESCRIPTION
**Ticket**: n/a

## Context

* I pulled the latest changes on `keg-cli` and was just poking around to get a better understanding of it
* I noticed on certain tasks, it contains more than just a `description` key and I figured it would be helpful to be able to print them out when using.`-help`

## Goal

* if an option is passed in before the `help` keyword, it will print out any extra details on that option item (if available)
* it will only print out the help for 1 option for now 
* help users see the options in detail when going through the `help` options

## Updates

* `src/libs/logger/showHelp.js`
    * added a new method to be able to pull in detail info for a given option item

## Testing

* run any help command with an option item passed in (not alias)
* example: `keg core start docker -h`
    - output: ![image](https://user-images.githubusercontent.com/3317835/85458180-ab5bf700-b555-11ea-8270-bb98747b7bd2.png)
