### PR TITLE
fix: Cleanup

### DIFF
--- a/src/__mocks__/helpers/globalConfig.js
+++ b/src/__mocks__/helpers/globalConfig.js
@@ -2,7 +2,7 @@ const path = require('path')
 
 const homeDir = require('os').homedir()
 const cliRoot = path.join(__dirname, '../../../')
-const kegHub = path.join(homeDir, '/keg-hub')
+const kegHub = process.env.KEG_ROOT_DIR || path.join(homeDir, './keg-hub')
 const kegRepos = path.join(kegHub, 'repos')
 const kegTaps = path.join(kegHub, 'taps')
 
@@ -53,7 +53,9 @@ module.exports = {
       errorStack: false
     },
     taps: {
-      test: { path: path.join(cliRoot, 'src/__mocks__/tap') },
+      test: {
+        path: path.join(cliRoot, 'src/__mocks__/tap')
+      },
     }
   },
   publish: {

--- a/src/constants/docker/containers.js
+++ b/src/constants/docker/containers.js
@@ -24,7 +24,8 @@ const DEFAULT = {
     clean: '--rm',
     nocache: '--no-cache',
     entrypoint: '--entrypoint',
-    connect: '-it'
+    connect: '-it',
+    squash: '--squash',
   },
   DEFAULTS: {
     clean: true,
@@ -32,6 +33,7 @@ const DEFAULT = {
     entrypoint: false,
     file: true,
     nocache: false,
+    squash: false,
   },
   ARGS: keyMap([
     'GIT_KEY',

--- a/src/libs/docker/image.js
+++ b/src/libs/docker/image.js
@@ -48,20 +48,21 @@ const tagImage = async (args, imgTag) => {
   const { item, tag, log, provider } = args
 
   // Get the image as an object
-  let image = args.image || await getImage(item)
+  let image = isObj(args.image) ? args.image : await getImage(item)
+
+  // If no image is found, then throw
+  !image && noItemFoundError('image', image)
 
   const opts = provider
     ? [ 'tag', image.id, tag ]
     : [ 'tag', image.id, `${image.rootId}:${tag}` ]
 
-  // If no image, then just throw, otherwise add the tag to the image
-  return !image
-    ? noItemFoundError('image', image)
-    : dockerCli({
-        ...args,
-        opts,
-        format: '',
-      })
+  // Add the tag to the image
+  return dockerCli({
+    ...args,
+    opts,
+    format: '',
+  })
 }
 
 /**

--- a/src/tasks/cli/env/set.js
+++ b/src/tasks/cli/env/set.js
@@ -31,17 +31,15 @@ const getEnv = (params, options) => {
  */
 const setEnv = async args => {
   const { params, options } = args
-  const { confirm } = params
+  const { force, confirm } = params
   const { key, value } = getEnv(params, options)
 
   const addKey = key.toUpperCase()
 
   await confirmExec({
-    execute: () => addDefaultEnv(addKey, value),
-    confirm: {
-      message: `Are you sure you want to add Global ENV ${addKey}?`,
-      default: true,
-    },
+    force,
+    execute: () => addDefaultEnv({ key: addKey, value, force: force || !confirm }),
+    confirm: `Are you sure you want to add Global ENV ${addKey}?`,
     preConfirm: !confirm,
     success: `The Global ENV key ${addKey} was Added!`,
     cancel: `Set Global ENV key was canceled!`,
@@ -78,6 +76,11 @@ module.exports = {
         description: "Confirm overwriting existing values.",
         example: 'keg cli env set key=MY_VALUE value=my_value --confirm false',
         default: true
+      },
+      force: {
+        description: "Force overwriting existing values, without asking for confirmation.",
+        example: 'keg cli env set key=MY_VALUE value=my_value --force',
+        default: false
       }
     },
   }

--- a/src/tasks/cli/env/unset.js
+++ b/src/tasks/cli/env/unset.js
@@ -13,10 +13,11 @@ const { confirmExec } = require('KegUtils/helpers/confirmExec')
  */
 const unsetEnv = async args => {
 
-  const { params: { key, confirm, comment } } = args
+  const { params: { force, key, confirm, comment }} = args
 
   await confirmExec({
-    execute: () => removeDefaultEnv(key, false, comment),
+    force,
+    execute: () => removeDefaultEnv({ key, comment, force }),
     confirm: `Are you sure you want to remove Global ENV ${key}?`,
     preConfirm: !confirm,
     success: `The Global ENV key ${key} was removed!`,
@@ -48,6 +49,11 @@ module.exports = {
         example: 'keg cli env unset --comment false',
         default: true,
       },
+      force: {
+        description: "Force overwriting existing values, without asking for confirmation.",
+        example: 'keg cli env set key=MY_VALUE value=my_value --force',
+        default: false
+      }
     },
   }
 }

--- a/src/utils/defaultEnvs/removeDefaultEnv.js
+++ b/src/utils/defaultEnvs/removeDefaultEnv.js
@@ -11,13 +11,14 @@ const { DEFAULT_ENV, GLOBAL_CONFIG_FOLDER } = require('KegConst/constants')
  * Removes an ENV from the Global Defaults.env file
  * @param {string} key - Name of the key to remove
  * @param {boolean} log - Should log any updates
+ * @param {boolean} force - Force unset the env value
  * @param {boolean} comment - Should turn env into comment instead of removing
  *
  * @returns {void}
  */
-const removeDefaultEnv = async (key, log, comment) => {
+const removeDefaultEnv = async ({ key, force, comment, log }) => {
 
-  !isStr(key) && generalError(`An ENV key is required as the first argument!`)
+  !isStr(key) && generalError(`An ENV key is required as an argument!`)
   
   // All envs are in upper case, so ensure the Key is also upper case
   const removeKey = key.toUpperCase()

--- a/src/utils/helpers/confirmExec.js
+++ b/src/utils/helpers/confirmExec.js
@@ -14,9 +14,9 @@ const { Logger } = require('KegLog')
  *
  * @returns {void}
  */
-const confirmExec = async ({ execute, confirm, preConfirm, success, cancel, args=[] }) => {
+const confirmExec = async ({ execute, force, confirm, preConfirm, success, cancel, args=[] }) => {
 
-  const confirmed = preConfirm === true
+  const confirmed = force || preConfirm === true
      ? true
      : await ask.confirm(confirm)
 


### PR DESCRIPTION
## Context
* These changes are part of a migration to how docker images are handled
* They were extracted out from a larger amount of changes to make the PR more consumable
* All changes may not make sense in this isolated context, but they are needed within a larger context

## Updates
  * Add ENV for setting the keg-hub root dir ( KEG_ROOT_DIR )
  * Added `--squash` option whe building docker images
  * Minor fix for tagging images to ensure the image exists
  * Added force option when setting / removing global cli ENVs
  * added force option to confirmExec helper
    * Overrides asking the user to confirm an operation

## Tests

**Test 1**
  * Pull this PR and run the tests => `keg cli && keg pr 27 && keg cli test`

**Test 2**
  * Test adding and remove global envs
    *  Run the cmd `keg cli env set --key MY_TEST_ENV --value duper`
      * It should ask if you want to add the global env MY_TEST_ENV
      * Select yes, then open you global cli config - `keg config open`
        * You should see it in the global `defaults.envs`, looks like this => http://snpy.in/2yM17i
    * Run the cmd `keg cli env unset --key MY_TEST_ENV`
      * It should ask if you want to remove the global env MY_TEST_ENV
      * Select yes, then open you global cli config - `keg config open` 
        * It should now be commented out in your defaults env
        * Now **delete** the env from your defaults.env file
    * Again,  run the cmd `keg cli env set --key MY_TEST_ENV --value duper`
    * Select **No** this time, and then ensure it was not added to your defaults.env 

**Test 3**
*  Run the cmd `keg cli env set --key MY_TEST_ENV --value duper --force`
   * It should add the env to your defaults.env, and **not** ask for permission
     * You should see it in the global `defaults.envs`
* Run the cmd `keg cli env unset --key MY_TEST_ENV --force --comment false`
  * It should remove the env from your defaults.env, and **not** ask for permission
    * The env should **not** be commented out. **It should be completely gone**
