### PR TITLE
Hotfix Compose Configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keg-cli",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Node.js CLI for working with Keg Repos and Taps",
   "main": "./keg",
   "repository": "https://github.com/lancetipton/Keg-CLI",

--- a/src/utils/task/globalOptions.js
+++ b/src/utils/task/globalOptions.js
@@ -46,7 +46,7 @@ const getGlobalOptions = (task, action) => {
       allowed: envOpts,
       description: 'Environment to run the task in',
       example: 'keg ${ task } ${ action } --env staging',
-      default: getDefaultEnv() || 'develop',
+      default: getDefaultEnv() || 'development',
     },
   }
 }


### PR DESCRIPTION
## Context

* The keg-cli should allow custom docker-compose config files defined from envs
* The current code is intended to allow this but, it broken

## Goal
* Fix the keg-cli to allow loading custom docker-compose config files defied from envs

## Updates
* `src/utils/docker/compose/addComposeConfigs.js`
  * Fixed the loading of compose configs from ENVs
* `src/utils/task/globalOptions.js`
  * Updated the default env to be `development`
    * We will switch to `develop` eventually, but as for now it should be `development`

## Testing

### Setup
* Pull this branch locally => `keg cli && keg pr 33`
* Pick a linked tap of choice, I used `keg-herkin`
* In the taps `container folder`, add a new file called `docker-compose-development.yml`
  * [Looks like this](http://snpy.in/3cnNsr)
  * Really the name of the file could be anything, because we define the path to it in the `values.yml` file
  * In the this new file add the code below.
    * Change `<service>` to be the actual service name of tap
      * For example `<service>` for keg-herkin is `keg-herkin`
    ```yml
    version: "3.8"
    services:
      <service>:
    ```
* In the taps `container/values.yml` file, add the following line
  * `KEG_COMPOSE_DEVELOPMENT: "{{ cli.taps.<tap-name>.path }}/container/docker-compose-development.yml"`
    * Replace `<tap-name>` with the name of the tap. Same name used when calling it form the terminal
      * For example `evf` for `tap-events-force` or `consumer` for `keg-test-consumer`
    * This tells the keg-cli how to find the `compose config` for the current tap, and environment
      * Which is why the name of the file does not matter
      * As long as the `KEG_COMPOSE_DEVELOPMENT` points to a yml file that can be loaded

> NOTES => Adding the compose config file, and the ENV to the values file
> tells the `keg-cli` to include it when running docker-compose commands


### Test
* After following the setup steps above exactly.
* Start the tap as you would normally
  * For example `keg herkin start`
* Once the tap is started, open another terminal window
* Get the id of the running taps docker container with `keg dc`, then copy the id from the output
  * [Looks like this](http://snpy.in/WMpWor)
* Next, run the command `docker container inspect <container-id>`
  * This should display the meta data for the container
  * Search for the text `com.docker.compose.project.config_files`
    * This is a label which stores the compose configs used when starting the container
  * Ensure the value includes the path to the `docker-compose-development.yml` file we created above
  * [Looks like this](http://snpy.in/ZF5xw8)
