### PR TITLE
Hotfix(loaders): Allow custom ENVs by container name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keg-cli",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Node.js CLI for working with Keg Repos and Taps",
   "main": "./keg",
   "repository": "https://github.com/lancetipton/Keg-CLI",

--- a/src/constants/docker/loaders.js
+++ b/src/constants/docker/loaders.js
@@ -51,6 +51,9 @@ const loadEnvFiles = args => {
     // ENVs in the global config folder based on current environment
     // Example => ~/.kegConfig/local.env
     path.join(GLOBAL_CONFIG_FOLDER, `${ env }.env`),
+    // ENVs in the global config folder based on current container
+    // Example => ~/.kegConfig/core.env
+    path.join(GLOBAL_CONFIG_FOLDER, `${ container }.env`),
     // ENVs in the global config folder based on current container and environment
     // Example => ~/.kegConfig/core-local.env
     path.join(GLOBAL_CONFIG_FOLDER, `${ container }-${ env }.env`),
@@ -84,6 +87,8 @@ const buildValueDup = (rootPath, env, container) => {
     ? []
     : container
       ? [
+          path.join(rootPath, `${ container }_values.yml`),
+          path.join(rootPath, `${ container }-values.yml`),
           path.join(rootPath, `${ container }_values_${ env }.yml`),
           path.join(rootPath, `${ container }-values-${ env }.yml`),
         ]


### PR DESCRIPTION
[Semver-Status] patch
* Load custom envs based on the containers name from the `~/.kegConfig` folder