### PR TITLE
General updates

### DIFF
--- a/containers/proxy/values.yml
+++ b/containers/proxy/values.yml
@@ -1,6 +1,7 @@
 
 env:
   # --- LOCAL ENV CONTEXT --- #
+  IMAGE: 'keg-proxy'
 
   KEG_DOCKER_FILE: "{{ cli.paths.containers }}/proxy/Dockerfile"
   KEG_VALUES_FILE: "{{ cli.paths.containers }}/proxy/values.yml"

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,0 +1,80 @@
+# Docker Images Workflow
+
+### Overview
+  * In most cases, images should not be built locally
+  * Images should be built in the cloud, for example a `github workflow`
+  * When an image is needed locally, it should pulled from a provider
+  * They can built manually if needed by running the build task
+    * This is how we would create the initial image for a new tap
+    * Or if changes to how an existing image is built, is needed
+
+### Base Image
+  * Should only be needed locally when:
+    * You need to change how an image is built
+    * You are building a new image for a tap
+  * All images use the base image, but only when being built
+    * All images should be built in the CI (except new ones)
+  * Anytime there are changes pushed to the `keg-hub` master branch
+    * A new base image is built
+    * Using this new base image, new keg-hub images are built
+    * This process should be automated inside a github action
+
+### Process 
+* Build base image with master tag
+  * This is the starting point for all other images
+* Build base images for keg-hub repos with default tag ( master )
+  * They should all use the `base:master` image in the `FROM` of the Dockerfile
+  * Images include `keg-core`, `keg-components`, `tap`
+
+### Taps
+  * In most cases taps should use the `tap:master` image as it's base
+    * This should be defined with the `KEG_BASE_IMAGE` env
+      * It should include the image name and tag
+  * For creating a new Tap
+    * Define the container folder, and add the required files
+    * Manually build a new image
+      * Even in this case, the base image should be pulled from the provider first
+      * It should not need to build the base image locally
+    * Tag it with `master`, then push it to your provider
+      * This should happen automatically
+    * All further development should just pull that image
+
+### Workflow
+  * **Pushing an Image**
+    * Should automatically tag an image with the correct tag ( git branch / default tag )
+      * This will allow the image to be different from PR images when testing PRs
+    * Use the `keg docker package` || `keg dpg` (shortcut) to push an image with changes
+      * This is exactly the same as before
+    * Only use the `push` task directly when the `<image-base>:master` image needs to be updated
+  * **Running an Image**
+    * Should automatically pull from the docker provider any time an image is started
+    * Should pull the most recent version of the `KEG_IMAGE_FROM` from the provider
+      * In most cases this would be the `master` tagged version
+
+### Important ENVS
+  * `KEG_BASE_IMAGE`: ghcr.io/simpleviewinc/tap:master
+    * Image to use when building a tap
+    * Docker will use this image when building the image
+    * Should be `tap:master` in most cases
+      * This is default, but can be over written (i.e. Keg-Herkin)
+  * `KEG_IMAGE_FROM`: ghcr.io/simpleviewinc/<tap-name>:master
+    * Image to use when running a tap
+    * Docker Compose will use this image when starting the container
+
+### Image Tags
+  * New Images should use the current branch as the tag name
+    * For example `keg-core:develop, keg-components:my-branch-name, tap:master`
+  * This allows for images in PR's to be `auto-updated` as needed
+    * This can be done through a github action whenever changes are pushed to that branch with an open PR
+    * We would no longer have to manually commit, and push images for our PR requests
+  * This also allows for them to work consistently with the `keg-proxy`
+    * Which uses the branch name within the dynamically built url
+  * Other tags can be added, but they should only be used for reference if needed
+
+### Building/Testing Images Locally
+  * Most of the time, you shouldn't need to do this
+  * But when you make changes that require building a new image, such as by making changes to the Dockerfile, you can follow this workflow
+    * Build the image, tag it, and push it to the registry
+      * example: `keg evf build --tag my-changes-tag --push`
+    * Then, to test it, run the package locally using the `--from` flag:
+      * example: `keg evf start --from evf:my-changes-tag`

--- a/docs/images.md
+++ b/docs/images.md
@@ -78,3 +78,4 @@
       * example: `keg evf build --tag my-changes-tag --push`
     * Then, to test it, run the package locally using the `--from` flag:
       * example: `keg evf start --from evf:my-changes-tag`
+      * ensure you use the same branch as the one you were on when you ran `build`, otherwise the mutagen sync will overwrite changes within the docker container

--- a/src/__mocks__/libs/docker/data.js
+++ b/src/__mocks__/libs/docker/data.js
@@ -268,6 +268,7 @@ const dockerObjLabels = {
     'com.keg.proxy.domain': 'components'
   },
   proxy: {
+    'com.keg.env.context': 'keg-proxy',
     'com.keg.path.container': '/keg/tap',
     'com.keg.path.compose': 'keg-cli/containers/proxy/docker-compose.yml',
     'com.keg.path.values': 'keg-cli/containers/proxy/values.yml',

--- a/src/tasks/docker/package/package.js
+++ b/src/tasks/docker/package/package.js
@@ -89,11 +89,16 @@ const dockerPackage = async args => {
   // Really the ID should be coming from buildContainerContext
   // Need to investigate why
 
-  // Ensure we get the container ID, either from the container context
-  // Or from the container context for internal apps or the image name
-  const { id } = containerContext.id
+  const resolvedContainerContext = containerContext.id
     ? containerContext
     : await docker.container.get(CONTEXT_TO_CONTAINER[cmdContext] || image)
+
+  if (!resolvedContainerContext || !resolvedContainerContext.id)
+    generalError('Container context id is not available. Are you sure you have the container running?')
+
+  // Ensure we get the container ID, either from the container context
+  // Or from the container context for internal apps or the image name
+  const { id } = resolvedContainerContext
 
   // Get the current branch name at the location
   const currentBranch = tag || await getCommitTag(location)

--- a/src/tasks/docker/package/package.js
+++ b/src/tasks/docker/package/package.js
@@ -97,7 +97,7 @@ const dockerPackage = async args => {
 
   const id = get(resolvedContainerContext, 'id')
   if (!id)
-    generalError(`Container context id is not available. Are you sure you the container "${image}" exists?`)
+    generalError(`Container context id is not available. Are you sure the container "${image}" exists?`)
 
   // Get the current branch name at the location
   const currentBranch = tag || await getCommitTag(location)

--- a/src/tasks/docker/package/package.js
+++ b/src/tasks/docker/package/package.js
@@ -89,16 +89,15 @@ const dockerPackage = async args => {
   // Really the ID should be coming from buildContainerContext
   // Need to investigate why
 
+  // Ensure we get the container context, either from the existing container context
+  // Or from the container context for internal apps, or the image name
   const resolvedContainerContext = containerContext.id
     ? containerContext
     : await docker.container.get(CONTEXT_TO_CONTAINER[cmdContext] || image)
 
-  if (!resolvedContainerContext || !resolvedContainerContext.id)
-    generalError('Container context id is not available. Are you sure you have the container running?')
-
-  // Ensure we get the container ID, either from the container context
-  // Or from the container context for internal apps or the image name
-  const { id } = resolvedContainerContext
+  const id = get(resolvedContainerContext, 'id')
+  if (!id)
+    generalError(`Container context id is not available. Are you sure you the container "${image}" exists?`)
 
   // Get the current branch name at the location
   const currentBranch = tag || await getCommitTag(location)

--- a/src/tasks/proxy/attach.js
+++ b/src/tasks/proxy/attach.js
@@ -34,7 +34,7 @@ module.exports = {
       cmd: {
         description: 'Docker container command to run. Default ( /bin/bash )',
         example: 'keg proxy att --cmd test',
-        default: 'bash'
+        default: '/bin/sh'
       },
       options: {
         alias: [ 'opts' ],

--- a/src/tasks/proxy/attach.js
+++ b/src/tasks/proxy/attach.js
@@ -32,7 +32,7 @@ module.exports = {
     example: 'keg proxy attach',
     options: {
       cmd: {
-        description: 'Docker container command to run. Default ( /bin/bash )',
+        description: 'Docker container command to run. Default: /bin/sh',
         example: 'keg proxy att --cmd test',
         default: '/bin/sh'
       },

--- a/src/utils/task/checkLinkedTaps.js
+++ b/src/utils/task/checkLinkedTaps.js
@@ -122,9 +122,6 @@ const setupTapTask = async ({ globalConfig, allTasks, command, options }) => {
       params: { tap: command }
     }, globalConfig)
 
-  // Add the tap as the second-to-last option incase last option is the help option
-  taskData.options.splice(taskData.options.length - 1, 0, `tap=${ command }`)
-
   return taskData
 }
 


### PR DESCRIPTION
## Goal

* Just fixing and adding a few things

## Updates

* `containers/proxy/values.yml`
  * `keg proxy att` was failing for two reasons, this was one of them
  * it couldn't find the container name in the context 
* `src/tasks/proxy/attach.js`
  * this was the other reason: `bash` isn't available in the proxy container, but `/bin/sh` is, so I changed it to use that as the `cmd` default
* `docs/images.md`
  * just uploading the docker images workflow that Lance wrote a few months ago
  * I did add one section at the end about building images locally'
* `src/tasks/docker/package/package.js`
  * previously, whenever you ran the `pack` command but the container didn't exist, keg-cli would output a very unhelpful error message about a null/undefined value
  * I just added a check for that and a more helpful error message
* `src/utils/task/checkLinkedTaps.js`
  * remove a line that was adding `tap=<tap_name>` to the options array
  * this was breaking the help command whenever it was run with a linked tap
  * example: running `keg deploy build -h` would only print out the "tap" parameter, not all the remaining parameters
    * this is because the command was spliced with option `tap=<tap_name>`, so the help logger thinks the user only wants to see docs for the "tap" parameter,
  * it doesn't seem like this splicing was being used anywhere, but let me know if I'm missing something!

## Testing
* `keg proxy att`
  * verify you can attach to the proxy container
* `keg evf kill` && `keg evf pack`
  * verify you see a helpful error message for the `pack` task
* run `keg evf start` (or whatever container), ensure it starts, then run `keg evf pack` and verify it packs the image
* run `keg deploy build -h`(or any linked tap)
  * verify you see docs for ALL the build parameters that this linked tap inherits


