### PR TITLE
Watchtower proxy

### DIFF
--- a/containers/proxy/docker-compose.yml
+++ b/containers/proxy/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       # All other docker containers use a sub-domain
       - traefik.http.routers.api.rule=Host(`${KEG_PROXY_HOST}`)
       - traefik.http.routers.api.service=api@internal
+
+      # Watchtower; https://containrrr.dev/watchtower/arguments/#filter_by_enable_label
+      # TODO: make this label assignment dynamic, for any container
+      - com.centurylinklabs.watchtower.enable=${KEG_WATCHTOWER_ENABLED}
     ports:
       - ${PROXY_INSECURE_PORT}:${PROXY_INSECURE_PORT:-80}
       - ${PROXY_SECURE_PORT}:${PROXY_SECURE_PORT:-443}

--- a/containers/proxy/values.yml
+++ b/containers/proxy/values.yml
@@ -33,3 +33,6 @@ env:
 
   # Entry port for trafik to route to keg containers
   PROXY_ENTRY_PORT: 80
+
+  # Ensures watchtower won't restart the container when a new image is found (default is true)
+  KEG_WATCHTOWER_ENABLED: false


### PR DESCRIPTION
## Goal

* We don't want the proxy being restarted by watchtower

## Updates

* Added label to tell watchtower to ignore the proxy

## Testing

* ssh onto the keg staging server
* ensure the `keg-cli` is on this branch (`keg pr 48`)
* run `keg watchtower start --debug --runOnce --att`
* verify that the logs do not mention it pulling the `traefik` image/container at all
