### PR TITLE
Add constants checking

### DIFF
--- a/docs/docker/envs.md
+++ b/docs/docker/envs.md
@@ -8,7 +8,6 @@
 ### KEG_EXEC_CMD vs KEG_DOCKER_EXEC
 * TODO - explain difference and reasoning for them
 
-
 ### ENV Functionality
 * **DOC_APP_PATH**
   * Path to the application within the docker image or container
@@ -57,5 +56,18 @@
 * **KEG_EXEC_CMD**
   * TODO
 * **KEG_DOCKER_EXEC**
-  * * TODO
+  * TODO
+* **KEG_AUTO_SYNC**
+  * Disables creating a mutagen sync from a tap's folder and the docker container
+  * Definition
+    * @optional
+    * @type *Boolean*
+    * @cli-option `N/A`
+* **KEG_USE_PROXY**
+  * Disables keg-proxy container check when executing a task
+  * Definition
+    * @optional
+    * @type *Boolean*
+    * @cli-option `N/A`
+
 * *more coming soon...*

--- a/docs/docker/envs.md
+++ b/docs/docker/envs.md
@@ -54,17 +54,32 @@
     * @type *string*
     * @cli-option `N/A`
 * **KEG_EXEC_CMD**
-  * TODO
-* **KEG_DOCKER_EXEC**
-  * TODO
+  * The command within the container to call when running the `docker exec command`
+    * Most tap's `Dockerfile` defines running the `container/run.sh` script when starting
+    * The `container/run.sh` script then uses `KEG_EXEC_CMD` as the `yarn` script to be run
+      * Looks something like `yarn <KEG_EXEC_CMD>`
+    * This ENV will be **ignored**, unless configure in a fashion similar to above
+  * Definition
+    * @optional
+    * @type *String*
+    * @cli-option `--exec`
+* **KEG_AUTO_DOCKER_EXEC***
+  * Disables calling docker exec command after starting the docker container
+  * Must explicitly set to `false`
+  * Definition
+    * @optional
+    * @type *Boolean*
+    * @cli-option `N/A`
 * **KEG_AUTO_SYNC**
   * Disables creating a mutagen sync from a tap's folder and the docker container
+  * Must explicitly set to `false`
   * Definition
     * @optional
     * @type *Boolean*
     * @cli-option `N/A`
 * **KEG_USE_PROXY**
   * Disables keg-proxy container check when executing a task
+  * Must explicitly set to `false`
   * Definition
     * @optional
     * @type *Boolean*

--- a/src/utils/helpers/__tests__/checkEnvConstantValue.js
+++ b/src/utils/helpers/__tests__/checkEnvConstantValue.js
@@ -1,0 +1,52 @@
+const { DOCKER } = require('KegConst/docker')
+const { testEnum } = require('KegMocks/jest/testEnum')
+
+const globalConfig = global.getGlobalCliConfig()
+
+const { checkEnvConstantValue } = require('../checkEnvConstantValue')
+
+const testArgs = {
+  envDoesNotMatch: {
+    description: 'It returns false when the ENV value does not match',
+    inputs: ['core', 'KEG_EXEC_CMD', 'test:cmd'],
+    outputs: false
+  },
+  envDoesNotExistMatchTrue: {
+    description: 'It returns false when the ENV does not exist and matchValue is true',
+    inputs: ['core', 'NOT_VALID_TEST_ENV', true],
+    outputs: false
+  },
+  envDoesNotExistMatchFalse: {
+    description: 'It returns false when the ENV does not exist and matchValue is false',
+    inputs: ['core', 'NOT_VALID_TEST_ENV', false],
+    outputs: false
+  },
+  noContextPassed: {
+    description: 'It returns false when no context is passed',
+    inputs: [null, 'KEG_EXEC_CMD', 'test-match-value'],
+    outputs: false
+  },
+  noEnvPassed: {
+    description: 'It returns false when no ENV is passed',
+    inputs: ['core', null, 'test-match-value'],
+    outputs: false
+  },
+  envExistsNoMatchValue: {
+    description: 'It returns true when the ENV value exists and not match value is passed',
+    inputs: ['core', 'KEG_PROXY_PORT'],
+    outputs: true
+  },
+  envMatchesMatchValue: {
+    description: 'It returns true when the ENV value matches the passed in match value',
+    inputs: ['core', 'DOC_APP_PATH', '/keg/keg-core'],
+    outputs: true
+  },
+}
+
+describe('checkEnvConstantValue', () => {
+
+  afterAll(() => jest.resetAllMocks())
+
+  testEnum(testArgs, checkEnvConstantValue)
+
+})

--- a/src/utils/helpers/checkEnvConstantValue.js
+++ b/src/utils/helpers/checkEnvConstantValue.js
@@ -1,0 +1,23 @@
+const { exists } = require('@keg-hub/jsutils')
+const { getContainerConst } = require('KegUtils/docker/getContainerConst')
+
+/**
+ * Checks if a constant env matches the passed in matchValue
+ * If no matchValue is passed, then the value is returned
+ * @function
+ * @param {string} context - The container context to pull the ENVs from
+ * @param {string} constant - The ENV constant to check
+ * @param {*} matchValue - The value the ENV constant is checked against
+ *
+ * @returns {boolean} - If the ENV constant matches the matchValue or exists when no matchValue
+ */
+const checkEnvConstantValue = (context, constant, matchValue) => {
+  const value = getContainerConst(context, `ENV.${constant}`)
+  return exists(matchValue)
+    ? value === matchValue
+    : Boolean(value)
+}
+
+module.exports = {
+  checkEnvConstantValue
+}

--- a/src/utils/services/proxyService.js
+++ b/src/utils/services/proxyService.js
@@ -1,6 +1,7 @@
 const docker = require('KegDocCli')
 const { runInternalTask } = require('KegUtils/task/runInternalTask')
 const { getContainerConst } = require('KegUtils/docker/getContainerConst')
+const { checkEnvConstantValue } = require('KegUtils/helpers/checkEnvConstantValue')
 
 /**
  * Checks if the proxy container exists, and if not, starts it
@@ -14,7 +15,9 @@ const proxyService = async args => {
   const { tap, context } = params
 
   // Check if the container need the keg-proxy started
-  const startProxy = getContainerConst(tap || context, 'ENV.KEG_USE_PROXY', true)
+  // If KEG_USE_PROXY is set to false then don't start the proxy
+  // If it's true or not defined, then start the proxy
+  const startProxy = !checkEnvConstantValue(tap || context, 'KEG_USE_PROXY', false)
   if(startProxy === false) return false
 
   // Make call to check if the keg-proxy container exists

--- a/src/utils/services/startService.js
+++ b/src/utils/services/startService.js
@@ -3,6 +3,7 @@ const { composeService } = require('./composeService')
 const { pullService } = require('./pullService')
 const { proxyService } = require('./proxyService')
 const { getServiceArgs } = require('./getServiceArgs')
+const { getContainerConst } = require('KegUtils/docker/getContainerConst')
 
 /**
  * Runs the build service, then the compose service
@@ -19,18 +20,24 @@ const { getServiceArgs } = require('./getServiceArgs')
 const startService = async (args, exArgs) => {
   // Build the service arguments
   const serviceArgs = getServiceArgs(args, exArgs)
-
+  const cmdContext = get(serviceArgs, 'params.tap', get(serviceArgs, 'params.context'))
+  
   // Call the proxy service to make sure that is running
   await proxyService(serviceArgs)
 
   // Call the build service to ensure required images are built 
   const { imgNameContext, isNewImage } = await pullService(serviceArgs, 'compose')
 
+  const internalOpts = { imgNameContext }
+  // Setup internal options for running the docker exec command can creating the muatagen auto-sync
+  getContainerConst(cmdContext, 'ENV.KEG_DOCKER_EXEC') && (internalOpts.skipDockerExec = true)
+  getContainerConst(cmdContext, 'ENV.KEG_AUTO_SYNC') && (internalOpts.skipDockerSyncs = true)
+
   // Call the compose service to start the application
   // Pass in recreate, base on if a new image was pulled
   // Set 'pull' param to false, because we already did that above
   return await composeService(deepMerge(serviceArgs, {
-    __internal: { imgNameContext },
+    __internal: internalOpts,
     params: { pull: false, recreate: isNewImage },
   }))
 

--- a/src/utils/services/startService.js
+++ b/src/utils/services/startService.js
@@ -29,7 +29,7 @@ const startService = async (args, exArgs) => {
   const { imgNameContext, isNewImage } = await pullService(serviceArgs, 'compose')
 
   const internalOpts = { imgNameContext }
-  // Setup internal options for running the docker exec command can creating the muatagen auto-sync
+  // Setup internal options for running the docker exec command can creating the mutagen auto-sync
   getContainerConst(cmdContext, 'ENV.KEG_DOCKER_EXEC') && (internalOpts.skipDockerExec = true)
   getContainerConst(cmdContext, 'ENV.KEG_AUTO_SYNC') && (internalOpts.skipDockerSyncs = true)
 


### PR DESCRIPTION
### Context
* There are some cases where we need to disable some of the default keg-cli functionality
* I added some envs to allow this

### Updates
* Added more docs about `ENV`'s
* Added envs
  * `KEG_AUTO_DOCKER_EXEC` - disables auto docker exec call
  * `KEG_AUTO_SYNC` - disables auto mutagen sync creation
  * `KEG_USE_PROXY` - disables checking the keg-proxy
* Added helper for check if an ENV value matches a passed in value

### Tests
**Setup**
* Pull this pr => `keg cli && keg pr 52`
* Pick a tap, I used `tap-events-force`

**Test 1**
* Kill the tap if it's running => `keg evf kill`
* Add the `KEG_AUTO_DOCKER_EXEC: false` env to the taps values.yml file
* Run the taps start command `keg evf start`
  * Ensure it starts the container, but does **NOT** run the exec command
  * [Looks like this](http://snpy.in/G4z0Ep)

**Test 2**
* Kill the tap if it's running => `keg evf kill`
* Add the `KEG_AUTO_SYNC: false` env to the taps values.yml file
* Run the taps start command `keg evf start`
  * Ensure it starts the container, but does **NOT** create a mutagen sync
    * A log message is printed out when a sync is created, you should not see it when starting the tap
    * [Looks like this](http://snpy.in/3crMwv)
  * After it starts, run the `keg sy` command
    * Ensure the no sync exists for the tap in the output

**Test 3**
* Kill the tap if it's running => `keg evf kill`
* Kill the `keg-proxy` => `keg proxy kill`
* Add the `KEG_USE_PROXY: false` env to the taps values.yml file
* Run the command `docker network create keg-hub-net`
  * The `keg-proxy` creates a network for all the containers to connect to
  * If it's not running, then we must do it manually by running the above command
* Run the taps start command `keg evf start`
  * Ensure the proxy is not started when the tap starts
    * After the tap start, run the command `keg dc`
    * Ensure the `keg-proxy` is not running
