### PR TITLE
Zen 609 automate packages - Part 2

### DIFF
--- a/containers/components/docker-compose.yml
+++ b/containers/components/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - CHOKIDAR_USEPOLLING
       - DOC_APP_PATH
+      - DOC_BUILD_PATH
       - DOC_RETHEME_PATH
       - DOC_JSUTILS_PATH
       - KEG_EXEC_CMD

--- a/containers/components/run.sh
+++ b/containers/components/run.sh
@@ -1,24 +1,25 @@
 #!/usr/bin/env
 
+# Hides annoying story-book warnings
+export SUPPRESS_SUPPORT=1
+
+# Ensure required envs are set
+[[ -z "$KEG_PROXY_PORT" ]] && KEG_PROXY_PORT=60710
+[[ -z "$DOC_APP_PATH" ]] && DOC_APP_PATH=/keg/keg-components
+[[ -z "$DOC_BUILD_PATH" ]] && DOC_BUILD_PATH==/keg/components-build
+
 # If the no KEG_DOCKER_EXEC env is set, just sleep forever
 # This is to keep our container running forever
-if [ -z "$KEG_DOCKER_EXEC" ]; then
-  tail -f /dev/null
-  exit 0
+[[ -z "$KEG_DOCKER_EXEC" ]] && tail -f /dev/null && exit 0;
 
-else
-
-  # cd into the tap repo
-  cd $DOC_APP_PATH
-
-  # Check if no exect command exists, or if it's set to web
-  # Then default it to storybook
-  if [ -z "$KEG_EXEC_CMD" ] || [ "$KEG_EXEC_CMD" == "web" ]; then
-    KEG_EXEC_CMD="sb"
-  fi
-
-  # Start the tap instance
-  echo $"[ KEG-CLI ] Running command 'yarn $KEG_EXEC_CMD'" >&2
-  yarn $KEG_EXEC_CMD
-
+# Check the NODE_ENV, and use that to know which environment to start
+# For non-development environments, we want to serve the bundle if it exists
+if [[ ! " development develop local test " =~ " $NODE_ENV " ]]; then
+  [[ -d "$DOC_BUILD_PATH" ]] && npx serve $DOC_BUILD_PATH --cors -n -l $KEG_PROXY_PORT && exit 0;
+  echo $"[ KEG-CLI ] Serve path $DOC_BUILD_PATH does not exist!" >&2
 fi
+
+# Serve the app bundle in development environemnts
+echo $"[ KEG-CLI ] Running development server!" >&2
+cd $DOC_APP_PATH
+[[ -z "$KEG_EXEC_CMD" || "$KEG_EXEC_CMD" == 'web' ]] && yarn sb || yarn $KEG_EXEC_CMD

--- a/containers/components/values.yml
+++ b/containers/components/values.yml
@@ -3,11 +3,11 @@ actions:
     build:
       cmds:
         - yarn sb:build
-        - rm -rf /keg/components-build
-        - cp -R /keg/keg-components/docs /keg/components-build
+        - rm -rf {{ envs.DOC_BUILD_PATH }}
+        - cp -R /keg/keg-components/docs {{ envs.DOC_BUILD_PATH }}
     serve:
       cmds:
-        - npx serve /keg/components-build --cors -n -l {{ envs.KEG_PROXY_PORT }}
+        - npx serve {{ envs.DOC_BUILD_PATH }} --cors -n -l {{ envs.KEG_PROXY_PORT }}
 env:
   # --- LOCAL ENV CONTEXT --- #
 
@@ -35,6 +35,7 @@ env:
   # Location of the application within the docker container
   # Defines the WORKDIR within the Dockerfile and docker-compose.yml
   DOC_APP_PATH: /keg/keg-components
+  DOC_BUILD_PATH: /keg/components-build
 
   # Defines the location in a docker container for a dependency
   # This allows mutagen to know where to sync the local version of the dependency

--- a/containers/core/docker-compose.yml
+++ b/containers/core/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - CHOKIDAR_USEPOLLING
       - DOC_APP_PATH
+      - DOC_BUILD_PATH
       - DOC_COMPONENTS_PATH
       - DOC_RESOLVER_PATH
       - DOC_RETHEME_PATH

--- a/containers/core/run.sh
+++ b/containers/core/run.sh
@@ -1,23 +1,22 @@
 #!/usr/bin/env
 
+# Ensure required envs are set
+[[ -z "$KEG_PROXY_PORT" ]] && KEG_PROXY_PORT=19006
+[[ -z "$DOC_APP_PATH" ]] && DOC_APP_PATH=/keg/keg-core
+[[ -z "$DOC_BUILD_PATH" ]] && DOC_BUILD_PATH==/keg/core-build
+
 # If the no KEG_DOCKER_EXEC env is set, just sleep forever
 # This is to keep our container running forever
-if [ -z "$KEG_DOCKER_EXEC" ]; then
-  tail -f /dev/null
-  exit 0
+[[ -z "$KEG_DOCKER_EXEC" ]] && tail -f /dev/null && exit 0;
 
-else
-
-  # cd into the tap repo
-  cd $DOC_APP_PATH
-
-  # Check if no exect command exists, then default it to web
-  if [ -z "$KEG_EXEC_CMD" ]; then
-    KEG_EXEC_CMD="web"
-  fi
-
-  # Start the tap instance
-  echo $"[ KEG-CLI ] Running command 'yarn $KEG_EXEC_CMD'" >&2
-  yarn $KEG_EXEC_CMD
-
+# Check the NODE_ENV, and use that to know which environment to start
+# For non-development environments, we want to serve the bundle if it exists
+if [[ ! " development develop local test " =~ " $NODE_ENV " ]]; then
+  [[ -d "$DOC_BUILD_PATH" ]] && npx serve $DOC_BUILD_PATH --cors -n -l $KEG_PROXY_PORT && exit 0;
+  echo $"[ KEG-CLI ] Serve path $DOC_BUILD_PATH does not exist!" >&2
 fi
+
+# Serve the app bundle in development environemnts
+echo $"[ KEG-CLI ] Running development server!" >&2
+cd $DOC_APP_PATH
+[[ -z "$KEG_EXEC_CMD" ]] && yarn web || yarn $KEG_EXEC_CMD

--- a/containers/core/values.yml
+++ b/containers/core/values.yml
@@ -1,4 +1,14 @@
-
+actions:
+  tap:
+    build:
+      cmds:
+        - yarn web:build
+        - rm -rf {{ envs.DOC_BUILD_PATH }}
+        - cp -R {{ envs.DOC_APP_PATH }}/web-build {{ envs.DOC_BUILD_PATH }}
+    serve:
+      detach: true
+      cmds:
+        - npx serve {{ envs.DOC_BUILD_PATH }} --cors -n -l {{ envs.KEG_PROXY_PORT }}
 env:
   # --- LOCAL ENV CONTEXT --- #
   COMPONENTS_PATH: "{{ cli.paths.components }}"
@@ -32,6 +42,8 @@ env:
   # --- DOCKER ENV CONTEXT --- #
 
   DOC_APP_PATH: /keg/keg-core
+
+  DOC_BUILD_PATH: /keg/core-build
 
   # Port the application will use when running within the container
   # Required to allow the keg-proxy to route traffic to it

--- a/containers/tap/docker-compose.yml
+++ b/containers/tap/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     environment:
       - CHOKIDAR_USEPOLLING
       - DOC_APP_PATH
+      - DOC_BUILD_PATH
       - DOC_CLI_PATH
       - DOC_CORE_PATH
       - DOC_COMPONENTS_PATH

--- a/containers/tap/run.sh
+++ b/containers/tap/run.sh
@@ -1,34 +1,27 @@
 #!/usr/bin/env
 
+# Ensure required envs are set
+[[ -z "$KEG_PROXY_PORT" ]] && KEG_PROXY_PORT=19006
+[[ -z "$DOC_BUILD_PATH" ]] && DOC_BUILD_PATH=/keg/tap-build
+
+# If DOC_TAP_PATH is set, use that for the DOC_APP_PATH
+[[ "$DOC_TAP_PATH" ]] && export DOC_APP_PATH=$DOC_TAP_PATH
+# Otherwise set the default if it's not already set
+[[ -z "$DOC_APP_PATH" ]] && DOC_APP_PATH=/keg/tap
 
 # If the no KEG_DOCKER_EXEC env is set, just sleep forever
 # This is to keep our container running forever
-if [ -z "$KEG_DOCKER_EXEC" ]; then
-  tail -f /dev/null
-  exit 0
+[[ -z "$KEG_DOCKER_EXEC" ]] && tail -f /dev/null && exit 0;
 
-else
-
-  # Normalize DOC_TAP_PATH
-  if [ "$DOC_TAP_PATH" ]; then
-    DOC_APP_PATH=$DOC_TAP_PATH
-  fi
-
-  # Ensure the DOC_APP_PATH is set
-  if [ -z "$DOC_APP_PATH" ]; then
-    DOC_APP_PATH=/keg/tap
-  fi
-
-  # cd into the tap repo
-  cd $DOC_APP_PATH
-
-  # Ensure there is a command to run
-  if [ -z "$KEG_EXEC_CMD" ]; then
-    KEG_EXEC_CMD="start"
-  fi
-
-  # Start the tap instance
-  echo $"[ KEG-CLI ] Running command 'yarn $KEG_EXEC_CMD'" >&2
-  yarn $KEG_EXEC_CMD
-
+# Check the NODE_ENV, and use that to know which environment to start
+# For non-development environments, we want to serve the bundle if it exists
+if [[ ! " development develop local test " =~ " $NODE_ENV " ]]; then
+  [[ -d "$DOC_BUILD_PATH" ]] && npx serve $DOC_BUILD_PATH --cors -n -l $KEG_PROXY_PORT && exit 0;
+  echo $"[ KEG-CLI ] Serve path $DOC_BUILD_PATH does not exist!" >&2
 fi
+
+# Serve the app bundle in development environemnts
+echo $"[ KEG-CLI ] Running development server!" >&2
+cd $DOC_APP_PATH
+yarn ${KEG_EXEC_CMD:-start}
+

--- a/containers/tap/values.yml
+++ b/containers/tap/values.yml
@@ -1,4 +1,14 @@
-
+actions:
+  tap:
+    build:
+      cmds:
+        - yarn web:build
+        - rm -rf {{ envs.DOC_BUILD_PATH }}
+        - cp -R {{ envs.DOC_CORE_PATH }}/web-build {{ envs.DOC_BUILD_PATH }}
+    serve:
+      detached: true
+      cmds:
+        - npx serve {{ envs.DOC_BUILD_PATH }} --cors -n -l {{ envs.KEG_PROXY_PORT }}
 env:
   # --- LOCAL ENV CONTEXT --- #
   COMPONENTS_PATH: "{{ cli.paths.components }}"
@@ -43,6 +53,9 @@ env:
 
   # Default location of the tap in the docker container
   DOC_APP_PATH: /keg/tap
+
+  # Default location of the tap web bundle export
+  DOC_BUILD_PATH: /keg/tap-build
 
   # Defines the location in a docker container for a dependency
   # This allows mutagen to know where to sync the local version of the dependency

--- a/src/tasks/docker/package/package.js
+++ b/src/tasks/docker/package/package.js
@@ -186,6 +186,7 @@ module.exports = {
       ...require('./run'),
     },
     options: mergeTaskOptions(`docker`, `package`, `push`, {
+      context: {},
       push: {
         description: 'Push the packaged image up to a docker provider registry',
         example: `keg docker package --no-push`,


### PR DESCRIPTION
**Ticket**: [ZEN-609](https://jira.simpleviewtools.com/browse/ZEN-609)

* This PR should be reviewed along side [this keg-herkin pr](https://github.com/simpleviewinc/keg-herkin/pull/41)
* This PR should be reviewed along side [this tap-evf pr](https://github.com/simpleviewinc/tap-events-force/pull/129)
* This PR should be reviewed along side [this keg-hub pr](https://github.com/simpleviewinc/keg-hub/pull/152)

> This is part 2 of the overall task.
> In this part, it updates the run.sh scripts of the docker images
> The scripts now check the `NODE_ENV` and run a different command based on that


## Context
* When we run our docker packages on the staging server, there are a number of features that we don't need, like running in development modes
* These features slow down the execution, and in some cases prevent resolving the application url

## Goal
* Automate bundling the application when the docker image is created
* This will allow the staging server serve the bundle instead of using the development server

## Updates
* `containers/*/run.sh`
  * Re-wrote the run.sh scripts for `core`, `components`, and `tap`
    * Runs different cmds based on `NODE_ENV`
* `containers/*/docker-compose.yml`
  * Added `DOC_BUILD_PATH` for web build export path
* `containers/*/values.yml`
  * Added actions to the `Values.yml` files
  * Added `DOC_BUILD_PATH` for web build export path

## Tests

**Setup**
* Pull this PR => `keg cli && keg pr 61`

**Test 1*
* Start the tap => `keg components start`
* Connect to the container with => `keg components att`
* Next open another terminal window run => `keg dpg --context components`
  * Ensure it automatically runs the `tap.build` action defined in the `container/Values.yml` file
  * [Looks like this](https://prnt.sc/11w9586)
* After it's been built, you can press `ctl+c` to cancel to exit that task or let it finish and push to the docker provider
  * I've already pushed images to the provider, so there's not need for you to do this unless you want to
  * The image will be used in a later test

**Test 2**
* Leave the components container running, but stop **ALL** running servers
  * This includes the one started from the `keg components start` command
* Connect to the container with => `keg components att`
* Navigate to the build folder with => `cd /keg/components-build`
  * Ensure the folder exists, and contains the build files
  * [Looks like this](https://prnt.sc/11w9c7r)

**Test 3**
* Because the keg-components run.sh file get copied at build time
  * We have to manually copy it, to allow testing it, So...
    * Running the following command should work =>
      * `keg cli && keg d cp --local $(pwd)/containers/components/run.sh --container keg-components --remote /keg/components-run.sh --src local`
        * At some point this task should be updated to make it easier to run
        * The upside is it allows you to do it in one command
    * If that does not work, you have to get the docker container's ID
      * Run `keg dc`, then find the container and copy it's id
      * Then run this command, replace `<container-id>` with the id from the `keg dc` command
        * `keg cli && docker cp ./containers/components/run.sh <container-id>:/keg/components-run.sh`
* Once the file is copied, run the command `bash /keg/components-run.sh`
  * Ensure this starts the development server
  * [Looks like this](https://prnt.sc/11wa9sm)
  * Once verified, hit `ctrl+c` to stop the server
* Next, run the command `NODE_ENV=staging bash /keg/components-run.sh`
  * Ensure this starts the bundle server instead
  * [Looks like this](https://prnt.sc/11wab33)
  * Navigate to http://components-zen-609-automate-package-exec.local.keghub.io/ in your browser
    * Ensure the keg-components resolves in the browser

**Test 4**
* Kill the running keg-components container => `keg components kill`
* Next, run the command `keg dpg run --package keg-components:zen-609-automate-package-exec --env staging`
  * This should start the keg-components application using the bundled application code
  * [Looks like this](https://prnt.sc/11w71u6)
* Navigate to http://components-zen-609-automate-package-exec.local.keghub.io/ in your browser
  * Ensure the keg-components resolves in the browser

**Test 5**
* Do the tests in this PR => `https://github.com/simpleviewinc/keg-herkin/pull/41`
* Do the tests in this PR => `https://github.com/simpleviewinc/tap-events-force/pull/129`
