### PR TITLE
Proxy Route Tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "log-update": "4.0.0",
     "module-alias": "2.2.2",
     "ngrok": "3.2.7",
+    "open": "^8.0.6",
     "qrcode-terminal": "0.12.0",
     "rimraf": "3.0.2",
     "semver": "^7.3.2",

--- a/src/__mocks__/proxy/index.js
+++ b/src/__mocks__/proxy/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('./routes')
+}

--- a/src/__mocks__/proxy/routes.js
+++ b/src/__mocks__/proxy/routes.js
@@ -1,0 +1,73 @@
+const proxyRoutes = [
+  {
+    entryPoints: [ 'keg' ],
+    service: 'api@internal',
+    rule: 'Host(`local.keghub.io`)',
+    status: 'enabled',
+    using: [ 'keg' ],
+    name: 'api@docker',
+    provider: 'docker'
+  },
+  {
+    entryPoints: [ 'traefik' ],
+    service: 'api@internal',
+    rule: 'PathPrefix(`/api`)',
+    priority: 2147483646,
+    status: 'enabled',
+    using: [ 'traefik' ],
+    name: 'api@internal',
+    provider: 'internal'
+  },
+  {
+    entryPoints: [ 'keg' ],
+    service: 'components-test-proxy-route',
+    rule: 'Host(`components-test-proxy-route.local.keghub.io`)',
+    status: 'enabled',
+    using: [ 'keg' ],
+    name: 'components-test-proxy-route@docker',
+    provider: 'docker'
+  },
+  {
+    entryPoints: [ 'traefik' ],
+    middlewares: [ 'dashboard_redirect@internal', 'dashboard_stripprefix@internal' ],
+    service: 'dashboard@internal',
+    rule: 'PathPrefix(`/`)',
+    priority: 2147483645,
+    status: 'enabled',
+    using: [ 'traefik' ],
+    name: 'dashboard@internal',
+    provider: 'internal'
+  },
+  {
+    entryPoints: [ 'keg' ],
+    service: 'evf-test-proxy-route',
+    rule: 'Host(`evf-test-proxy-route.local.keghub.io`)',
+    status: 'enabled',
+    using: [ 'keg' ],
+    name: 'evf-test-proxy-route@docker',
+    provider: 'docker'
+  },
+  {
+    entryPoints: [ 'traefik' ],
+    service: 'ping@internal',
+    rule: 'PathPrefix(`/ping`)',
+    priority: 2147483647,
+    status: 'enabled',
+    using: [ 'traefik' ],
+    name: 'ping@internal',
+    provider: 'internal'
+  },
+  {
+    entryPoints: [ 'keg' ],
+    service: 'retheme-test-proxy-route',
+    rule: 'Host(`retheme-test-proxy-route.local.keghub.io`)',
+    status: 'enabled',
+    using: [ 'keg' ],
+    name: 'retheme-test-proxy-route@docker',
+    provider: 'docker'
+  }
+]
+
+module.exports = {
+  proxyRoutes
+}

--- a/src/tasks/proxy/list.js
+++ b/src/tasks/proxy/list.js
@@ -1,0 +1,112 @@
+const axios = require('axios')
+const { Logger } = require('KegLog')
+const { limbo, isArr, noOpObj, wordCaps } = require('@keg-hub/jsutils')
+const { generalError } = require('KegUtils/error/generalError')
+const { getSetting } = require('KegUtils/globalConfig/getSetting')
+
+const defFilters = [
+  'dashboard@internal',
+  'ping@internal',
+  'api@internal'
+]
+
+/**
+ * Gets a list of all containers registered to the keg-proxy
+ * @param {Object} env - The env the keg-proxy was started in
+ *
+ * @returns {Array} - List of container routes from traefik
+ */
+const getListFromAPI = async env => {
+  const domain = getSetting('defaultDomain')
+  const [ err, res ] = await limbo(axios.get(`http://${env}.${domain}/api/http/routers`))
+
+  return err
+    ? generalError(err.message)
+    : !isArr(res.data)
+      ? generalError(`No routes returned from the proxy server!`, res)
+      : res.data
+}
+
+/**
+ * Filters items returned from the traefik api based on the passed in filter
+ * @param {Object} items - Items returned from traefik api
+ * @param {string} filter - Text content that items should contain to be included
+ *
+ * @returns {Array} - All items that match the passed in filter
+ */
+const filterList = (list, filter) => {
+  return list.reduce((filtered, item) => {
+    item &&
+      (!filter || !(
+        (filter !== 'no-internal' && !item.service.includes(filter)) ||
+        defFilters.includes(item.service)
+      )) &&
+      filtered.push(item)
+
+    return filtered
+  }, [])
+
+}
+
+/**
+ * Logs the items returned from the traefik api to the terminal
+ * @param {Object} items - Items returned from traefik api after being filtered
+ *
+ * @returns {Void}
+ */
+const logList = list => {
+  Logger.subHeader(`Keg-Proxy Container Routes`)
+  list.map(item => {
+    const [ name, ...rest ] = item.service.split('-')
+    Logger.yellow(`  ${ wordCaps(name) }`)
+
+    const branch = rest.join('-')
+    Logger.pair(`    * ${branch}:`, `https://${item.rule.split('`')[1]}`)
+  })
+  Logger.empty()
+}
+
+/**
+ * Lists all containers registered to the keg-proxy
+ * @param {Object} args - arguments passed from the runTask method
+ * @param {string} args.command - Initial command being run
+ * @param {Array} args.options - arguments passed from the command line
+ * @param {Object} args.tasks - All registered tasks of the CLI
+ * @param {Object} globalConfig - Global config object for the keg-cli
+ *
+ * @returns {void}
+ */
+const listProxy = async args => {
+  const { params, __internal=noOpObj } = args
+  const { filter, env} = params
+  const log = __internal.skipLog !== true && params.log
+
+  const list = await getListFromAPI(env)
+  const filtered = filterList(list, filter)
+  log && logList(filtered)
+
+  return filtered
+}
+
+module.exports = {
+  list: {
+    name: 'list',
+    alias: [ 'ls', 'print', 'pr' ],
+    action: listProxy,
+    description: `Lists the currently running containers and their URLs`,
+    example: 'keg proxy list <options>',
+    options: {
+      filter: {
+        description: 'Filter items displayed the printed list. Matching items will be shown',
+        example: 'keg proxy list --filter proxy',
+        default: 'no-internal'
+      },
+      log: {
+        alias: [ 'lg', 'print', 'pr' ],
+        description: 'Print the items to the terminal',
+        example: 'keg proxy list --no-log',
+        default: true
+      }
+    }
+  }
+}

--- a/src/tasks/proxy/list.js
+++ b/src/tasks/proxy/list.js
@@ -24,7 +24,7 @@ const logList = list => {
 
   // Print each group to the terminal
   mapObj(groups, (name, items) => {
-    Logger.yellow(`  ${ wordCaps(name) }`)
+    Logger.blue(`  ${ wordCaps(name) }`)
     items.map(item => Logger.log(item.url))
     Logger.empty()
   })

--- a/src/tasks/proxy/open.js
+++ b/src/tasks/proxy/open.js
@@ -20,7 +20,7 @@ const askForRoute = async items => {
 
       return `${wordCaps(name)}${branch}${url}`
     }),
-    'Proxy Routs: ( Route | URL )\n',
+    'Proxy Routes: ( Route | URL )\n',
     'Select a Route:'
   )
   return items[index]

--- a/src/tasks/proxy/open.js
+++ b/src/tasks/proxy/open.js
@@ -1,0 +1,75 @@
+const open = require('open')
+const { Logger } = require('KegLog')
+const { ask } = require('@keg-hub/ask-it')
+const { wordCaps } = require('@keg-hub/jsutils')
+const { getProxyRoutes } = require('KegUtils/proxy/getProxyRoutes')
+const { filterProxyRoutes } = require('KegUtils/proxy/filterProxyRoutes')
+
+/**
+ * Asks the user to select a route from a list of routes
+ * @param {Array} items - Items returned from traefik api after being filtered
+ *
+ * @returns {Object} - Selected item from the list of passed in items
+ */
+const askForRoute = async items => {
+  const index = await ask.promptList(
+    items.map(item => {
+      const [ name, ...rest ] = item.service.split('-')
+      const branch = rest.length ? `-${rest.join('-')}\n` : '\n'
+      const url = `       * http://${item.rule.split('`')[1]}\n`
+
+      return `${wordCaps(name)}${branch}${url}`
+    }),
+    'Proxy Routs: ( Route | URL )\n',
+    'Select a Route:'
+  )
+  return items[index]
+}
+
+/**
+ * Lists all containers registered to the keg-proxy
+ * @param {Object} args - arguments passed from the runTask method
+ * @param {string} args.command - Initial command being run
+ * @param {Array} args.options - arguments passed from the command line
+ * @param {Object} args.tasks - All registered tasks of the CLI
+ * @param {Object} globalConfig - Global config object for the keg-cli
+ *
+ * @returns {void}
+ */
+const openProxy = async args => {
+  const { params } = args
+  const { context, env } = params
+
+  const list = await getProxyRoutes(env)
+  const filtered = filterProxyRoutes(list, context)
+
+  !filtered.length &&
+    context &&
+    Logger.warn(`\nCould not find any routes for ${context}!\n`)
+
+  const item = filtered.length > 1
+      ? await askForRoute(filtered)
+      : filtered.pop()
+
+  const url = item && item.rule.split('`')[1]
+
+  return url
+    ? await open(`http://${url}`)
+    : Logger.warn(`\nNo route found, skipping!\n`)
+}
+
+module.exports = {
+  open: {
+    name: 'open',
+    alias: [ 'op' ],
+    action: openProxy,
+    description: `Open a proxy route with the host machines default browser`,
+    example: 'keg proxy open <options>',
+    options: {
+      context: {
+        description: 'Nam of the proxy route to open. Can be a partial name',
+        example: 'keg proxy open --context components',
+      },
+    }
+  }
+}

--- a/src/tasks/proxy/proxy.js
+++ b/src/tasks/proxy/proxy.js
@@ -8,6 +8,7 @@ module.exports = {
       ...require('./build'),
       ...require('./destroy'),
       ...require('./list'),
+      ...require('./open'),
       ...require('./stop'),
       ...require('./start'),
     },

--- a/src/tasks/proxy/proxy.js
+++ b/src/tasks/proxy/proxy.js
@@ -7,6 +7,7 @@ module.exports = {
       ...require('./attach'),
       ...require('./build'),
       ...require('./destroy'),
+      ...require('./list'),
       ...require('./stop'),
       ...require('./start'),
     },

--- a/src/utils/proxy/filterProxyRoutes.js
+++ b/src/utils/proxy/filterProxyRoutes.js
@@ -1,0 +1,27 @@
+
+/**
+ * Filters items returned from the traefik api based on the passed in filter
+ * @param {Object} items - Items returned from traefik api
+ * @param {string} filter - Text content that items should contain to be included
+ *
+ * @returns {Array} - All items that match the passed in filter
+ */
+const filterProxyRoutes = (list, filter) => {
+
+  return list.reduce((filtered, item) => {
+    // Only include the internal routes if a filter is passed
+    // This allows access to all routes via a filter, but does not display them by default
+    const includeInternal = Boolean(filter || (!filter && !item.rule.startsWith('PathPrefix')))
+
+    item &&
+      includeInternal &&
+      (!filter || item.rule.includes(filter)) &&
+      filtered.push(item)
+
+    return filtered
+  }, [])
+}
+
+module.exports = {
+  filterProxyRoutes
+}

--- a/src/utils/proxy/getProxyRoutes.js
+++ b/src/utils/proxy/getProxyRoutes.js
@@ -1,0 +1,27 @@
+const axios = require('axios')
+const { limbo, isArr } = require('@keg-hub/jsutils')
+const { generalError } = require('KegUtils/error/generalError')
+const { getSetting } = require('KegUtils/globalConfig/getSetting')
+
+/**
+ * Gets a list of all containers registered to the keg-proxy
+ * @param {string} env - The env the keg-proxy was started in
+ * @param {string} host - Domain when the proxy is running
+ *
+ * @returns {Array} - List of container routes from traefik
+ */
+const getProxyRoutes = async (env, host) => {
+  const domain = host || getSetting('defaultDomain')
+  const subdomain = env || getSetting('defaultEnv')
+  const [ err, res ] = await limbo(axios.get(`http://${subdomain}.${domain}/api/http/routers`))
+
+  return err
+    ? generalError(err.message)
+    : !isArr(res.data)
+      ? generalError(`No routes returned from the proxy server!`, res)
+      : res.data
+}
+
+module.exports = {
+  getProxyRoutes
+}

--- a/src/utils/proxy/index.js
+++ b/src/utils/proxy/index.js
@@ -1,5 +1,7 @@
 module.exports = {
+  ...require('./filterProxyRoutes'),
   ...require('./generateComposeLabels'),
   ...require('./getProxyDomainFromBranch'),
   ...require('./getProxyDomainFromLabel'),
+  ...require('./getProxyRoutes'),
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2204,6 +2204,11 @@ deepmerge@^4.2.2:
   resolved "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 define-properties@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -2894,6 +2899,11 @@ is-docker@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
   integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+
+is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -4007,6 +4017,15 @@ onetime@^5.1.0:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+open@^8.0.6:
+  version "8.0.6"
+  resolved "https://registry.npmjs.org/open/-/open-8.0.6.tgz#bdf94a80b4ef5685d8c7b58fb0fbbe5729b37204"
+  integrity sha512-vDOC0KwGabMPFtIpCO2QOnQeOz0N2rEkbuCuxICwLMUCrpv+A7NHrrzJ2dQReJmVluHhO4pYRh/Pn6s8t7Op6Q==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 optionator@^0.8.1:
   version "0.8.3"


### PR DESCRIPTION
## Context

* Sometimes it's a pain to figure out the url to a running application
* Currently we use the Traefik Admin UI, but there are no direct links to the apps
  * We have to go to the Admin UI in the borwser
  * Find the container route, and navigate to its page
  * Then copy and paste the url from the displayed rule, which is not always super clear

## Goal
* Make it easy to open apps in a browser that are registered to the proxy

## Updates
* Added to tasks to the proxy tasks that allow for opening a registered proxy route
  * `keg proxy list` => Lists all registered routes
    * Hides all internal routes by default, except for the the Admin UI route
    * Allows a filter option to filter the results
      * Using the filter includes internal routes
  * `keg proxy open` => Opens a route's url in the browser
    * Allows a context option to define the route to be open
    * If no context is passed, the user is asked to select a route from a list
      * Hides all internal routes by default, except for the the Admin UI route
      * If the context matches an internal route, it will be displayed

## Testing
* **TODO REMINDER**
  * This is to remind me to write tests for the proxy util methods added in the PR
  * If reviewing this PR, you can skip down the the **Setup** section below

**Setup**
  * Pull this pr => `keg cli && keg pr 62`
  * Start multiple taps/apps to allow testing
    * `keg evf start`
    * `keg retheme start`
    * `keg components start`

**Test 1**
* After starting a few taps / apps, run the cmd => `keg proxy ls` || `keg proxy list`
  * This should show a list of the registered routes
  * [Looks like this](https://prnt.sc/11xgmin)
  * Ensure the correct routes are displayed
* Next run the command => `keg proxy list components`
  * Ensure only show keg-components routes are displayed
  * [Looks like this](https://prnt.sc/11xgnec)
* Next run the command => `keg proxy list api`
  * Ensure only shows the internal api route
    * This is useless in our case, so you can see why I hid it by default
  * [Looks like this](https://prnt.sc/11xgovp)
* Try other filter combinations as needed

**Test 2**
* Run the cmd => `keg proxy open` || `keg proxy op`
  * Ensure is displays a list of available routes to open
  * [Looks like this](https://prnt.sc/11xgpfc)
* Select one of the routes
  * Enter the index of the route from the displayed list and press enter
* Ensure it then opens the selected route in your default browser
  * It uses the npm package [open](https://www.npmjs.com/package/open) to open the browser
  * Which means Firefox should work if it's your default, but I have not tested it
* Run the cmd again, but this time pass the linked name of one of the running taps or application
  * For example if `keg-components` is running, run the cmd => `keg proxy open components`
    * This should open `keg-components` in the browser
  * If the `evf-tap` is running, run the cmd => `keg proxy open evf`
    * This should open the `evf-tap` in the browser
