### PR TITLE
Kutils 0.1.0 fa923bc

### DIFF
--- a/repos/cli-utils/TODO.md
+++ b/repos/cli-utils/TODO.md
@@ -1,0 +1,7 @@
+# TODO
+
+### NPM Package
+  * Add mocks package
+
+### Commands
+  * Add sync version to processes

--- a/repos/cli-utils/TODO.md
+++ b/repos/cli-utils/TODO.md
@@ -1,7 +1,0 @@
-# TODO
-
-### NPM Package
-  * Add mocks package
-
-### Commands
-  * Add sync version to processes

--- a/repos/cli-utils/mocks.js
+++ b/repos/cli-utils/mocks.js
@@ -1,0 +1,1 @@
+module.exports = require('./__mocks__')

--- a/repos/cli-utils/package.json
+++ b/repos/cli-utils/package.json
@@ -11,6 +11,8 @@
     "access": "public"
   },
   "files": [
+    "__mocks__",
+    "mocks.js",
     "configs/",
     "index.js",
     "src/"
@@ -31,7 +33,7 @@
   "dependencies": {
     "@keg-hub/args-parse": "6.2.1",
     "@keg-hub/ask-it": "0.0.1",
-    "@keg-hub/jsutils": "8.1.0",
+    "@keg-hub/jsutils": "8.5.0",
     "@keg-hub/spawn-cmd": "0.1.0",
     "app-root-path": "3.0.0",
     "colors": "1.4.0",

--- a/repos/cli-utils/package.json
+++ b/repos/cli-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keg-hub/cli-utils",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Utility methods for writing Custom Tasks consumed by the Keg-CLI",
   "main": "index.js",
   "repository": "https://github.com/lancetipton/keg-cli-uilts",

--- a/repos/cli-utils/src/commands/__tests__/commands.js
+++ b/repos/cli-utils/src/commands/__tests__/commands.js
@@ -3,12 +3,14 @@ jest.resetAllMocks()
 jest.clearAllMocks()
 
 const spawnCmdMock = jest.fn()
-jest.setMock('@keg-hub/spawn-cmd', { spawnCmd: spawnCmdMock })
+const asyncCmdMock = jest.fn()
+jest.setMock('@keg-hub/spawn-cmd', { spawnCmd: spawnCmdMock, asyncCmd: asyncCmdMock })
 const errorLogMock = jest.fn()
 jest.setMock('../../logger/logger', { Logger: { error: errorLogMock }})
 
 const {
   runCmd,
+  execCmd,
   spawnCmd,
   dockerExec,
   ...shortcutCmds

--- a/repos/cli-utils/src/commands/commands.js
+++ b/repos/cli-utils/src/commands/commands.js
@@ -1,7 +1,7 @@
 const { getAppRoot } = require('../appRoot')
 const { Logger } = require('../logger/logger')
 const { isArr, noOpObj, noPropArr, camelCase, isStr, exists } = require('@keg-hub/jsutils')
-const { spawnCmd } = require('@keg-hub/spawn-cmd')
+const { spawnCmd, asyncCmd:execCmd } = require('@keg-hub/spawn-cmd')
 
 /**
  * Ensures the passed in data is an array
@@ -33,13 +33,17 @@ const ensureArray = (data=noPropArr) => (
  * @private
  * @param {string} cmd - Command to run in the child process
  * @param {Array} args - Arguments to pass to the cmd within the child process
- * @param {Object} env - Environment variables to be accessible in the child process
+ * @param {Object} options - Options forwarded to the child process
  * @param {string} cwd - Directory where the child process should be run from
+ * @param {boolean} asExec - Run command with execCmd instead of spawnCmd
  *
  * @returns {*} - Response from spawnCmd
  */
-const runCmd = (cmd, args=noPropArr, opts=noOpObj, cwd) => {
-  return spawnCmd(cmd, {
+const runCmd = (cmd, args=noPropArr, options=noOpObj, cwd, asExec) => {
+  const { exec, ...opts } = options
+  const runProc = (exec || asExec) ? execCmd : spawnCmd
+
+  return runProc(cmd, {
     args: ensureArray(args),
     options: { ...opts, env: { ...process.env, ...opts.env } },
     cwd: cwd || getAppRoot(),
@@ -81,6 +85,7 @@ const dockerExec = (containerName, args, ...opts) => {
 }
 
 module.exports = {
+  execCmd,
   runCmd,
   spawnCmd,
   dockerExec,

--- a/repos/cli-utils/src/fileSys/fileSys.js
+++ b/repos/cli-utils/src/fileSys/fileSys.js
@@ -360,7 +360,7 @@ const removeFile = file => limboify(fs.unlink, file)
  *
  * @returns {void}
  */
-const removeFileSync = file => fs.unlinkSync(filePath, callbackFunction)
+const removeFileSync = file => fs.unlinkSync(file, callbackFunction)
 
 /**
  * Wraps require in a try catch so app doesn't throw when require is called inline

--- a/repos/cli-utils/yarn.lock
+++ b/repos/cli-utils/yarn.lock
@@ -690,10 +690,10 @@
   resolved "https://registry.npmjs.org/@keg-hub/jsutils/-/jsutils-8.0.0.tgz#740e05e10128be53d2ffea72a6c8990b57745679"
   integrity sha512-omgYOX0p9H6GsQQ5onEJK56pUI/z1CoblFqjWy/SpwANwsuqEFEG3EKDdcRwwpLjaEl8qQWQzfQ1Z6Pc+OOgqQ==
 
-"@keg-hub/jsutils@8.1.0":
-  version "8.1.0"
-  resolved "https://registry.npmjs.org/@keg-hub/jsutils/-/jsutils-8.1.0.tgz#c5330ae7d38e603d580fa8596a8ebb31be0e4909"
-  integrity sha512-3ViC3u714kqg76ePFnSkZkSX8pnHzb31ltTADIO5f7tLm2Y9OcbtYWFrtDcH5RbP+Wmhyj43E2XYNTO4HHzdvA==
+"@keg-hub/jsutils@8.5.0":
+  version "8.5.0"
+  resolved "https://registry.npmjs.org/@keg-hub/jsutils/-/jsutils-8.5.0.tgz#cc81b730b6875d889e968100bd1302e0fb22d8f4"
+  integrity sha512-aF0mLfc1o0fRdoEaAopEkwCHfEKSz+Kjfb5goSELBkPJyulRzPz+6OTRk7XDV6VXtiq8kGJomGDAsBLW7htk4Q==
 
 "@keg-hub/spawn-cmd@0.1.0":
   version "0.1.0"


### PR DESCRIPTION
## Context

* When using the keg-cli utils in another app and writing tests; It would be helpful to allow importing the mocks from this repo
* There are times when we don't want to spawn a new process when running a cmd. It would be nice to have the ability to capture the output without out passing in events

## Goal

* Include the mocks in th npm package
* Add a way to run commands and capture the output without passing callback methods

## Updates

* `repos/cli-utils/mocks.js`
  * Export the `__mock__` folder
* `repos/cli-utils/package.json`
  *  Include the `mocks` in the NPM package
  * Update `jsutils`
* `repos/cli-utils/src/commands/commands.js` 
  * Add argument for using the `asyncCmd` instead of `spawnCmd`
  *  Export `execCmd` so it can be used directly
* `repos/cli-utils/src/fileSys/fileSys.js`
  * Fixed a fileSys bug

## Testing
* Run `keg cli && keg pr 65`
* Navigate to the `cli-utils` folder => `cd repos/cli-utils`
* Run `yarn install`
*  Run the tests => `yarn test`


