### PR TITLE
cli-utils fix run cmd

### DIFF
--- a/docs/docker/envs.md
+++ b/docs/docker/envs.md
@@ -84,5 +84,14 @@
     * @optional
     * @type *Boolean*
     * @cli-option `N/A`
+* **KEG_BASE_IMAGE**
+  * The base image to build a tap image
+  * Should be the full url of the image if using a provider other then the `dockerhub.io` default
+  * Typically it should look similar to `ghcr.io/simpleviewinc/tap:master`
+  * Setting it to `node:12.19-alpine` would pull the image from `dockerhub.io`, which is the default
+  * Definition
+    * @required
+    * @type *String*
+    * @cli-option `--from` (docker build task only)
 
 * *more coming soon...*

--- a/repos/cli-utils/src/commands/__tests__/commands.js
+++ b/repos/cli-utils/src/commands/__tests__/commands.js
@@ -79,7 +79,7 @@ describe('commands', () => {
 
     })
 
-    it(`Should join the options.evn with process.env`, async () => {
+    it(`Should join the options.env with process.env`, async () => {
       process.env.TEST_CLI_UTILS_PROC_ENV = `process.env`
       await runCmd('test', [], { env: { TEST_OPT_ENV: 'option.env' } }, process.cwd())
       const callOpts = spawnCmdMock.mock.calls[0][1].options

--- a/repos/cli-utils/src/commands/commands.js
+++ b/repos/cli-utils/src/commands/commands.js
@@ -37,17 +37,33 @@ const ensureArray = (data=noPropArr) => (
  * @param {string} cwd - Directory where the child process should be run from
  * @param {boolean} asExec - Run command with execCmd instead of spawnCmd
  *
- * @returns {*} - Response from spawnCmd
+ * @returns {Object|undefined} - Object is exec is true, undefined if false
  */
-const runCmd = (cmd, args=noPropArr, options=noOpObj, cwd, asExec) => {
-  const { exec, ...opts } = options
-  const runProc = (exec || asExec) ? execCmd : spawnCmd
+const runCmd = async (cmd, args=noPropArr, options=noOpObj, cwd, asExec) => {
+  const {
+    exec,
+    onStdOut,
+    onStdErr,
+    onError,
+    onExit,
+    ...opts
+  } = options
 
-  return runProc(cmd, {
-    args: ensureArray(args),
-    options: { ...opts, env: { ...process.env, ...opts.env } },
-    cwd: cwd || getAppRoot(),
-  })
+  return (exec || asExec)
+    ? await execCmd(
+        `${cmd} ${ensureArray(args).join(' ')}`,
+        { ...opts, env: { ...process.env, ...opts.env } },
+        cwd || getAppRoot()
+      )
+    : await spawnCmd(cmd, {
+        onStdOut,
+        onStdErr,
+        onError,
+        onExit,
+        args: ensureArray(args),
+        options: { ...opts, env: { ...process.env, ...opts.env } },
+        cwd: cwd || getAppRoot(),
+      })
 }
 
 /**

--- a/repos/cli-utils/src/network/__tests__/getAddresses.js
+++ b/repos/cli-utils/src/network/__tests__/getAddresses.js
@@ -1,3 +1,6 @@
+// Because the constants uses the os lib, we need to import them first before mocking it
+// That way we can load them and use the os lib without any errors
+// Then mock the os lib and the constants with the previously loaded constants
 const constants = require('../../constants/constants')
 jest.mock('os')
 jest.setMock('../../constants/constants', constants)

--- a/repos/cli-utils/src/network/__tests__/getAddresses.js
+++ b/repos/cli-utils/src/network/__tests__/getAddresses.js
@@ -1,5 +1,6 @@
-
+const constants = require('../../constants/constants')
 jest.mock('os')
+jest.setMock('../../constants/constants', constants)
 
 const { getAddresses }  = require('../')
 const { privateIPMock, publicIPMock } = require('../__mocks__/getAddresses')

--- a/repos/git-lib/yarn.lock
+++ b/repos/git-lib/yarn.lock
@@ -509,19 +509,20 @@
     colors "1.4.0"
     inquirer "7.0.6"
 
-"@keg-hub/cli-utils@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/@keg-hub/cli-utils/-/cli-utils-0.1.0.tgz#c7c25a90c06a4dc44ac0038c3a528930bead0b55"
-  integrity sha512-aDnjBJiSkFglgH2LCWfVp5O2CIVkFum/62CVvFYBiXHYtTERhwcRnAZaBB0+MfMRozQeK6SK/rTqjzNAvmzbBA==
+"@keg-hub/cli-utils@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/@keg-hub/cli-utils/-/cli-utils-0.2.1.tgz#8f156425a5d26bbec2392e88b624d76668443c89"
+  integrity sha512-htMJsJvp+aYOHDe19YS3rfPYEJNvj7HtqzzF6xrNdPIbztobXm4J7ufIfEFg3vYd0SanFScHabEGam9zytj8ug==
   dependencies:
     "@keg-hub/args-parse" "6.2.1"
     "@keg-hub/ask-it" "0.0.1"
     "@keg-hub/jsutils" "8.5.0"
-    "@keg-hub/spawn-cmd" "0.1.0"
+    "@keg-hub/spawn-cmd" "0.1.2"
     app-root-path "3.0.0"
     colors "1.4.0"
     fs-extra "9.0.1"
-    jest-cli "^26.6.3"
+    jest-cli "26.6.3"
+    module-alias "2.2.2"
 
 "@keg-hub/jsutils@0.0.1":
   version "0.0.1"
@@ -533,11 +534,6 @@
   resolved "https://registry.npmjs.org/@keg-hub/jsutils/-/jsutils-6.2.1.tgz#0d9dbf562e313eb7690d36a2b8e9147b1e08d52a"
   integrity sha512-aCZ86nB+f6awWbDIPd6VPaePQjm8AYNXvGrwe2Ip06F6oVJZ7tiOIBwFHeK/gAKqmw1wnxl4B0z21vQeINd6dw==
 
-"@keg-hub/jsutils@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.npmjs.org/@keg-hub/jsutils/-/jsutils-8.0.0.tgz#740e05e10128be53d2ffea72a6c8990b57745679"
-  integrity sha512-omgYOX0p9H6GsQQ5onEJK56pUI/z1CoblFqjWy/SpwANwsuqEFEG3EKDdcRwwpLjaEl8qQWQzfQ1Z6Pc+OOgqQ==
-
 "@keg-hub/jsutils@8.4.0":
   version "8.4.0"
   resolved "https://registry.npmjs.org/@keg-hub/jsutils/-/jsutils-8.4.0.tgz#e2dd2794ccc60f8c2e5ee1aa12ec6f8d9217c209"
@@ -547,17 +543,6 @@
   version "8.5.0"
   resolved "https://registry.npmjs.org/@keg-hub/jsutils/-/jsutils-8.5.0.tgz#cc81b730b6875d889e968100bd1302e0fb22d8f4"
   integrity sha512-aF0mLfc1o0fRdoEaAopEkwCHfEKSz+Kjfb5goSELBkPJyulRzPz+6OTRk7XDV6VXtiq8kGJomGDAsBLW7htk4Q==
-
-"@keg-hub/spawn-cmd@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/@keg-hub/spawn-cmd/-/spawn-cmd-0.1.0.tgz#4050dfa1681f4cfdf85ef27ca11724e1603b2b48"
-  integrity sha512-R+beqPFVga+XXRcnmALZe2VEYVk5S0eyhURLkOGFEJlbeQxvBZgcRdnEGVCQF7x65aw+A5ktDiOPtN9rEWsL8Q==
-  dependencies:
-    "@keg-hub/jsutils" "8.0.0"
-    app-root-path "3.0.0"
-    cross-spawn "7.0.3"
-    shell-exec "1.0.2"
-    tree-kill "1.2.1"
 
 "@keg-hub/spawn-cmd@0.1.2":
   version "0.1.2"
@@ -2056,7 +2041,7 @@ jest-changed-files@^26.6.2:
     execa "^4.0.0"
     throat "^5.0.0"
 
-jest-cli@^26.6.3:
+jest-cli@26.6.3:
   version "26.6.3"
   resolved "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz#43117cfef24bc4cd691a174a8796a532e135e92a"
   integrity sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
@@ -2672,6 +2657,11 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
+
+module-alias@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
+  integrity sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==
 
 ms@2.0.0:
   version "2.0.0"
@@ -3584,11 +3574,6 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
-
-tree-kill@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz#5398f374e2f292b9dcc7b2e71e30a5c3bb6c743a"
-  integrity sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==
 
 tree-kill@1.2.2:
   version "1.2.2"

--- a/repos/mutagen-lib/src/config.js
+++ b/repos/mutagen-lib/src/config.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const { error, fileSys, Logger } = require('@keg-hub/cli-utils')
-const { deepMerge, deepClone, isObj } = require('@keg-hub/jsutils')
+const { deepMerge, deepClone, isObj, isEmpty } = require('@keg-hub/jsutils')
 
 const { throwError } = error 
 const { stat, loadYml, writeYml } = fileSys
@@ -63,7 +63,7 @@ class Config {
   * @returns {Object} - Mutagen config
   */
   get = (overrides) => {
-    return !isObj(overrides)
+    return !isObj(overrides) || isEmpty(overrides)
       ? this.defaults
       : overrides.mergeDefault
         ? deepMerge(this.defaults, overrides)

--- a/src/utils/services/composeService.js
+++ b/src/utils/services/composeService.js
@@ -141,7 +141,10 @@ const composeService = async (args, exArgs=noOpObj) => {
   * prior to running the app in the container
   * Connect to the service and run the start cmd
   */
-  const { cmdContext, image } = composeContext
+
+  // The KEG_IMAGE_FROM env defines which image to use when starting the container
+  // So use the KEG_IMAGE_FROM env to get the start cmd
+  const { cmdContext, contextEnvs: { KEG_IMAGE_FROM } } = composeContext
 
   // Check if we should skip the docker exec command
   const internalSkipExec = get(args, '__internal.skipDockerExec')
@@ -158,7 +161,7 @@ const composeService = async (args, exArgs=noOpObj) => {
             serviceArgs.params,
             { detach: Boolean(get(serviceArgs, 'params.detach')) },
           ),
-          cmd: await getContainerCmd({ context: cmdContext, image }),
+          cmd: await getContainerCmd({ context: cmdContext, image: KEG_IMAGE_FROM }),
           context: cmdContext,
         },
       }))


### PR DESCRIPTION
## Goal

* cli-utils runCmd had some bugs that needed fixed
  * Also added more tests for it
* Added fix for one of the network tests that was failing due to a mock
  

## Updates

* Updated how runCmd calls the methods from `spawn-cmd`
  * Fixed issues with passing events
  *  Ensure it returns the correct response when calling the execCmd
* Added more tests

## Testing

* Pull this PR => `keg cli && keg pr 80`
* Move to the cli-utils repo => `keg cli && cd repos/cli-utils`
* Run `yarn test`
  * Ensure all tests pass 