### PR TITLE
Base Image and Container Command fixes

### DIFF
--- a/docs/docker/envs.md
+++ b/docs/docker/envs.md
@@ -84,5 +84,13 @@
     * @optional
     * @type *Boolean*
     * @cli-option `N/A`
+* **KEG_BASE_PROVIDER**
+  * Sets if the base image should be pulled from the configured docker provider
+  * Must explicitly set to `false`
+  * Definition
+    * @optional
+    * @type *Boolean*
+    * @cli-option `--no-useProvider`
+
 
 * *more coming soon...*

--- a/docs/docker/envs.md
+++ b/docs/docker/envs.md
@@ -84,8 +84,20 @@
     * @optional
     * @type *Boolean*
     * @cli-option `N/A`
-* **KEG_BASE_PROVIDER**
-  * Sets if the base image should be pulled from the configured docker provider
+* **KEG_BASE_IMAGE**
+  * The base image to build a tap image from
+  * Uses the docker configuration from the global config to set the docker provider and organization
+  * Typically this should be `ghcr.io/simpleviewinc/tap:master`
+  * Standard practice is set the full docker url for the image
+  * Definition
+    * @required
+    * @type *String*
+    * @cli-option `--from` (docker build task only)
+* **KEG_BASE_USE_PROVIDER**
+  * Use when the image defined in `KEG_BASE_IMAGE` is
+    * **Not** from the configured docker provider
+    * Does **NOT** include the full docker url
+  * It tells the `keg-cli` not to apply the configured docker url setting to the image
   * Must explicitly set to `false`
   * Definition
     * @optional

--- a/docs/docker/envs.md
+++ b/docs/docker/envs.md
@@ -85,10 +85,10 @@
     * @type *Boolean*
     * @cli-option `N/A`
 * **KEG_BASE_IMAGE**
-  * The base image to build a tap image from
-  * Uses the docker configuration from the global config to set the docker provider and organization
-  * Typically this should be `ghcr.io/simpleviewinc/tap:master`
-  * Standard practice is set the full docker url for the image
+  * The base image to build a tap image
+  * Should be the full url of the image if using a provider other then the `dockerhub.io` default
+  * Typically it should look similar to `ghcr.io/simpleviewinc/tap:master`
+  * Setting it to `node:12.19-alpine` would pull the image from `dockerhub.io`, which is the default
   * Definition
     * @required
     * @type *String*

--- a/docs/docker/envs.md
+++ b/docs/docker/envs.md
@@ -93,16 +93,5 @@
     * @required
     * @type *String*
     * @cli-option `--from` (docker build task only)
-* **KEG_BASE_USE_PROVIDER**
-  * Use when the image defined in `KEG_BASE_IMAGE` is
-    * **Not** from the configured docker provider
-    * Does **NOT** include the full docker url
-  * It tells the `keg-cli` not to apply the configured docker url setting to the image
-  * Must explicitly set to `false`
-  * Definition
-    * @optional
-    * @type *Boolean*
-    * @cli-option `--no-useProvider`
-
 
 * *more coming soon...*

--- a/repos/cli-utils/src/network/__tests__/getAddresses.js
+++ b/repos/cli-utils/src/network/__tests__/getAddresses.js
@@ -1,3 +1,6 @@
+// Because the constants uses the os lib, we need to import them first before mocking it
+// That way we can load them and use the os lib without any errors
+// Then mock the os lib and the constants with the previously loaded constants
 const constants = require('../../constants/constants')
 jest.mock('os')
 jest.setMock('../../constants/constants', constants)

--- a/repos/mutagen-lib/src/config.js
+++ b/repos/mutagen-lib/src/config.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const { error, fileSys, Logger } = require('@keg-hub/cli-utils')
-const { deepMerge, deepClone, isObj } = require('@keg-hub/jsutils')
+const { deepMerge, deepClone, isObj, isEmpty } = require('@keg-hub/jsutils')
 
 const { throwError } = error 
 const { stat, loadYml, writeYml } = fileSys
@@ -63,7 +63,7 @@ class Config {
   * @returns {Object} - Mutagen config
   */
   get = (overrides) => {
-    return !isObj(overrides)
+    return !isObj(overrides) || isEmpty(overrides)
       ? this.defaults
       : overrides.mergeDefault
         ? deepMerge(this.defaults, overrides)

--- a/src/tasks/docker/build.js
+++ b/src/tasks/docker/build.js
@@ -2,10 +2,9 @@ const docker = require('KegDocCli')
 const { Logger } = require('KegLog')
 const { DOCKER } = require('KegConst/docker')
 const { buildDockerCmd } = require('KegUtils/docker')
-const { throwRequired, throwNoTapLoc, generalError } = require('KegUtils/error')
 const { runInternalTask } = require('KegUtils/task/runInternalTask')
-const { getImgNameContext } = require('KegUtils/getters/getImgNameContext')
 const { mergeTaskOptions } = require('KegUtils/task/options/mergeTaskOptions')
+const { throwRequired, throwNoTapLoc, generalError } = require('KegUtils/error')
 const { buildContainerContext } = require('KegUtils/builders/buildContainerContext')
 
 /**
@@ -35,18 +34,10 @@ const createEnvFromBuildArgs = buildArgs => {
  *
  * @returns {string} - Base image to use when building
  */
-const getBaseImage = async ({ from, useProvider }, {  KEG_BASE_IMAGE, KEG_BASE_USE_PROVIDER }) => {
-  const baseImage = from || KEG_BASE_IMAGE || generalError(
+const getBaseImage = async ({ from }, {  KEG_BASE_IMAGE }) => {
+  return from || KEG_BASE_IMAGE || generalError(
     `To build an image, either the env KEG_BASE_IMAGE or the "from" parameter must be defined. Ensure you have one of these set.`
   )
-
-  // Use the from option if passed, or the KEG_BASE_IMAGE to get the build image context
-  const { full } = await getImgNameContext({ from: baseImage })
-
-  // Check if the base image should come from the configured docker provider
-  return useProvider === false || KEG_BASE_USE_PROVIDER === false
-    ? baseImage
-    : full
 }
 
 /**

--- a/src/tasks/docker/build.js
+++ b/src/tasks/docker/build.js
@@ -35,7 +35,7 @@ const createEnvFromBuildArgs = buildArgs => {
  *
  * @returns {string} - Base image to use when building
  */
-const getBaseImage = async ({ from, useProvider }, {  KEG_BASE_IMAGE, KEG_BASE_PROVIDER }) => {
+const getBaseImage = async ({ from, useProvider }, {  KEG_BASE_IMAGE, KEG_BASE_USE_PROVIDER }) => {
   const baseImage = from || KEG_BASE_IMAGE || generalError(
     `To build an image, either the env KEG_BASE_IMAGE or the "from" parameter must be defined. Ensure you have one of these set.`
   )
@@ -44,7 +44,7 @@ const getBaseImage = async ({ from, useProvider }, {  KEG_BASE_IMAGE, KEG_BASE_P
   const { full } = await getImgNameContext({ from: baseImage })
 
   // Check if the base image should come from the configured docker provider
-  return useProvider === false || KEG_BASE_PROVIDER === false
+  return useProvider === false || KEG_BASE_USE_PROVIDER === false
     ? baseImage
     : full
 }

--- a/src/utils/services/composeService.js
+++ b/src/utils/services/composeService.js
@@ -141,7 +141,10 @@ const composeService = async (args, exArgs=noOpObj) => {
   * prior to running the app in the container
   * Connect to the service and run the start cmd
   */
-  const { cmdContext, image } = composeContext
+
+  // The KEG_IMAGE_FROM env defines which image to use when starting the container
+  // So use the KEG_IMAGE_FROM env to get the start cmd
+  const { cmdContext, contextEnvs: { KEG_IMAGE_FROM } } = composeContext
 
   // Check if we should skip the docker exec command
   const internalSkipExec = get(args, '__internal.skipDockerExec')
@@ -158,7 +161,7 @@ const composeService = async (args, exArgs=noOpObj) => {
             serviceArgs.params,
             { detach: Boolean(get(serviceArgs, 'params.detach')) },
           ),
-          cmd: await getContainerCmd({ context: cmdContext, image }),
+          cmd: await getContainerCmd({ context: cmdContext, image: KEG_IMAGE_FROM }),
           context: cmdContext,
         },
       }))

--- a/src/utils/task/options/buildOptions.js
+++ b/src/utils/task/options/buildOptions.js
@@ -84,12 +84,6 @@ const buildOptions = (task, action, options) => {
       description: `Extra build args as key / value pairs to pass on to the docker build command.`,
       example: `keg ${task} ${action} --buildArgs custom:arg,other:arg`,
       type: 'array',
-    },
-    useProvider: {
-      alias: [ 'usp', 'upro' ],
-      description: 'Use the configured docker provider when building the base image',
-      example: `keg ${task} ${action} --no-useProvider`,
-      default: true
     }
   }
 }

--- a/src/utils/task/options/buildOptions.js
+++ b/src/utils/task/options/buildOptions.js
@@ -84,6 +84,12 @@ const buildOptions = (task, action, options) => {
       description: `Extra build args as key / value pairs to pass on to the docker build command.`,
       example: `keg ${task} ${action} --buildArgs custom:arg,other:arg`,
       type: 'array',
+    },
+    useProvider: {
+      alias: [ 'usp', 'upro' ],
+      description: 'Use the configured docker provider when building the base image',
+      example: `keg ${task} ${action} --no-useProvider`,
+      default: true
     }
   }
 }


### PR DESCRIPTION
## Goal
* Fix issue where a tap's base image is not from the configured docker provider
  * Now uses what ever `KEG_BASE_IMAGE` is set to
  * This means the `KEG_BASE_IMAGE` is required to be a full url or it will use dockers default which is `dockerhub.io`
* Fix issue when mutagen config overrides is an empty object, which causes the defaults to not be set
* Fix issue where the command to be executed in a docker container can not be found in some cases 

## Updates
* Add some docs / notes about `KEG_BASE_IMAGE`
* Fixed issue in the compose service that was using the wrong image when getting the docker run command

**IMAGE ENV Notes**
  * It was pulling `IMAGE`  ENV, which really should be removed at some point
  * With migration over to `KEG_IMAGE_FROM`, the `IMAGE` env should not longer be needed
  * It's still being used in some places, so it will take a bit more to fully remove it, so it's not part of this PR

## Testing
**Setup**
* Move to the keg-cli and pull this PR => `keg cli && keg pr 81`
* Clone the [tap-snack](https://github.com/simpleviewinc/tap-snack) repo locally
*  Be sure to link the `tap-snack` tap with  `snack`, if not done already
  * cd into the `tap-snack` repo and run `keg tap link snack`

**Test 1**
*  Run the command `keg snack start`
  * Navigate to http://snack-master.local.keghub.io/?app=kegcore
  * Ensure the tap-snack docker container runs as expected
  * For Appetize to load properly
    * Your Appetize **account** must have an app uploaded with the name `kegcore` 
      * If no app exists with that name, then you will see a message =>  `Missing required Appetize publicKey prop`
      * If an app does exist, the Appetize app should be displayed in via an iframe
        * If there are issues they are not part of this PR
        * Any issues are related to tap-snack, and will be handled in that repo
      * *Just make sure the website resolves

**Test 2**
* Run any other tap, and ensure it runs successfully
  * Due to `composeService` changes, the command to be executed is resolved a little differently
    * It now uses the `KEG_IMAGE_FROM` ENV
    * This makes it consistent with the actual image use running the image as a container
