### PR TITLE
fix(bug): Use default value when type is defined

### DIFF
--- a/repos/args-parse/src/__mocks__/testTasks.js
+++ b/repos/args-parse/src/__mocks__/testTasks.js
@@ -86,6 +86,26 @@ module.exports = {
         type: 'bool',
         default: false
       },
+      str: {
+        description: "defaults to Mr. Goat",
+        type: 'string',
+        default: 'Mr. Goat'
+      },
+      num: {
+        description: "defaults to 5001",
+        type: 'number',
+        default: 5001
+      },
+      arr: {
+        description: "defaults to [1, 2, 'buckle my shoe']",
+        type: 'array',
+        default: [1, 2, 'buckle my shoe']
+      },
+      obj: {
+        description: "defaults to { first: 1, second: 2, finally: 'buckle my shoe' }",
+        type: 'object',
+        default: { first: 1, second: 2, finally: 'buckle my shoe' }
+      },
     }
   },
 }

--- a/repos/args-parse/src/__tests__/argsParse.js
+++ b/repos/args-parse/src/__tests__/argsParse.js
@@ -240,12 +240,12 @@ describe('argsParse', () => {
       task: testTask5,
     })
 
-    expect(parsed.foo).toBe(true)
-    expect(parsed.bar).toBe(false)
-    expect(parsed.str).toBe('Mr. Goat')
-    expect(parsed.num).toBe(5001)
-    expect(parsed.arr).toEqual([1, 2, 'buckle my shoe'])
-    expect(parsed.obj).toEqual({ first: 1, second: 2, finally: 'buckle my shoe' })
+    expect(parsed.foo).toBe(testTask5.options.foo.default)
+    expect(parsed.bar).toBe(testTask5.options.bar.default)
+    expect(parsed.str).toBe(testTask5.options.str.default)
+    expect(parsed.num).toBe(testTask5.options.num.default)
+    expect(parsed.arr).toEqual(testTask5.options.arr.default)
+    expect(parsed.obj).toEqual(testTask5.options.obj.default)
 
   })
 

--- a/repos/args-parse/src/__tests__/argsParse.js
+++ b/repos/args-parse/src/__tests__/argsParse.js
@@ -233,36 +233,20 @@ describe('argsParse', () => {
 
   })
 
-  it('should convert an object type to an object when it is a colon string with multiple entries', async () => {
-    const expected = {
-      foo: "1",
-      bar: "2",
-      baz: 'hello'
-    }
+  it(`should use default when no option is passed and type and default exist`, async () => {
+
     const parsed = await argsParse({
-      args: [
-        "--object",
-        "foo:1,bar:2,baz:hello"
-      ],
-      task: testTask3,
+      args: [],
+      task: testTask5,
     })
 
-    expect(parsed.object).toEqual(expected)
-  })
+    expect(parsed.foo).toBe(true)
+    expect(parsed.bar).toBe(false)
+    expect(parsed.str).toBe('Mr. Goat')
+    expect(parsed.num).toBe(5001)
+    expect(parsed.arr).toEqual([1, 2, 'buckle my shoe'])
+    expect(parsed.obj).toEqual({ first: 1, second: 2, finally: 'buckle my shoe' })
 
-  it('should convert an object type to an object when it is a colon string with a single entry', async () => {
-    const expected = {
-      foo: "1",
-    }
-    const parsed = await argsParse({
-      args: [
-        "--object",
-        "foo:1"
-      ],
-      task: testTask3,
-    })
-
-    expect(parsed.object).toEqual(expected)
   })
 
   it('should call @keg-hub/ask-it when no value is passed and task.ask is exist', async () => {

--- a/repos/args-parse/src/args/ensureArgs.js
+++ b/repos/args-parse/src/args/ensureArgs.js
@@ -23,7 +23,7 @@ const ensureArg = async (task, args, key, meta) => {
   // See ./configs/parse.config.js for list of boolean shortcuts
   args[key] = checkBoolValue(args[key])
 
-  // Ensure evn shortcuts are mapped to the correct environment
+  // Ensure env shortcuts are mapped to the correct environment
   // Allows for using shortcuts like 'dev' or 'prod' for 'development' and 'production'
   // See ./configs/parse.config.js for list of env options
   args[key] = checkEnvArg(key, args[key], meta.default)
@@ -35,12 +35,12 @@ const ensureArg = async (task, args, key, meta) => {
   // If a value is found, then just return
   if(exists(args[key])) return args
 
-  // Check if we should ask the user for an option
+  // Check if we should ask the user for an option value
   let value = await optionsAsk(key, meta)
 
   // Run final check to ensure the argument exists
   // If no value exist at this point, check to see if it's required
-  // We treat empty string as no value
+  // We treat empty strings as no value
   ;!exists(value) || value === ''
     ? checkRequired(task, key, meta)
     : ( args[key] = checkBoolValue(value) )

--- a/repos/args-parse/src/args/ensureArgs.js
+++ b/repos/args-parse/src/args/ensureArgs.js
@@ -18,15 +18,29 @@ const { checkValueType } = require('../options/checkValueType')
  */
 const ensureArg = async (task, args, key, meta) => {
 
+  // Ensure any boolean shortcuts are mapped to true or false
+  // Allows for using shortcuts like 'yes' or 'no' for 'true' and 'false'
+  // See ./configs/parse.config.js for list of boolean shortcuts
   args[key] = checkBoolValue(args[key])
+
+  // Ensure evn shortcuts are mapped to the correct environment
+  // Allows for using shortcuts like 'dev' or 'prod' for 'development' and 'production'
+  // See ./configs/parse.config.js for list of env options
   args[key] = checkEnvArg(key, args[key], meta.default)
+
+  // Validate the metadata type, to ensure it matches the value
+  // If no value exists, it will return the meta.default
   args[key] = checkValueType(key, args[key], meta)
   
+  // If a value is found, then just return
   if(exists(args[key])) return args
 
+  // Check if we should ask the user for an option
   let value = await optionsAsk(key, meta)
 
-  // Treat empty string as no value
+  // Run final check to ensure the argument exists
+  // If no value exist at this point, check to see if it's required
+  // We treat empty string as no value
   ;!exists(value) || value === ''
     ? checkRequired(task, key, meta)
     : ( args[key] = checkBoolValue(value) )

--- a/repos/args-parse/src/options/checkValueType.js
+++ b/repos/args-parse/src/options/checkValueType.js
@@ -1,5 +1,5 @@
 const { checkBoolValue } = require('./checkBoolValue')
-const { toBool, toNum, isArr, isStr } = require('@keg-hub/jsutils')
+const { toBool, toNum, isArr, isStr, exists } = require('@keg-hub/jsutils')
 
 /**
  * Convert JSON string into object, wrapped in a try / catch.
@@ -71,6 +71,8 @@ const valueToObject = value => {
 
 /**
  * Convert the passed in value to a type based on the meta
+ * IMPORTANT - If no value exists, and meta.default does exist
+ *             It will return meta.default, which is NOT type validated
  * @function
  * @param {string} key - Option key from the task
  * @param {string} value - Data passed from cmd line
@@ -78,6 +80,10 @@ const valueToObject = value => {
  * @return {Object} - JSON object
  */
 const checkValueType = (key, value, meta) => {
+  // If the value does not exists, but a default does, return that
+  if(!exists(value) && exists(meta.default))
+    return meta.default
+
   if(!meta.type) return value
 
   switch(meta.type.toLowerCase()){


### PR DESCRIPTION
## Goal

* Fix bug in args-parse causing the default value to not be set when
  * The default value is defined for the option 
  * The type is defined for the option
  * No value is passed for the option when being parsed

## Updates

* Add more test cases for bug defined in Goal section
* Add comments to `ensureArg` method to help define what it's doing
* Add validate check to `checkValueType`
  * Checks if the value does not exist, and the default does
  * In this case it returns the default value
  * It does not `type` check the default value

### Notes

* At first I set it so it would also `type` check the `default value`, but there's a problem with this:
  * The consumer can **not** define the `default value`
  * If the `default value` does **not** match the defined `type`, it can cause issues when **no** `value` is passed
  * Really the person who wrote the `option definition` should ensure the `default` and `type` match
    * Unfortunately that would be hard to enforce without causing issues for the consumer

## Testing

* Pull the PR =>. `keg cli && keg pr 83`
* Move to the `args-parse` folder => `cd repos/args-parse`
* Run the tests => `yarn test`
  * Ensure all tests pass