### PR TITLE
More cli utils

### DIFF
--- a/repos/cli-utils/package.json
+++ b/repos/cli-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keg-hub/cli-utils",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Utility methods for writing Custom Tasks consumed by the Keg-CLI",
   "main": "index.js",
   "repository": "https://github.com/simpleviewinc/keg-cli/tree/master/repos/cli-utils",

--- a/repos/cli-utils/src/index.js
+++ b/repos/cli-utils/src/index.js
@@ -1,5 +1,7 @@
 const tap = require('./tap')
+const path = require('./path')
 const error = require('./error')
+const network = require('./network')
 const fileSys = require('./fileSys')
 const commands = require('./commands')
 const { Logger } = require('./logger')
@@ -7,7 +9,6 @@ const constants = require('./constants')
 const { runTask } = require('./runTask')
 const { registerTasks } = require('./tasks/tasks')
 const { getAppRoot, setAppRoot } = require('./appRoot')
-const network = require('./network')
 
 const {
   getKegGlobalConfig,
@@ -20,6 +21,7 @@ module.exports = {
   ...commands,
   ...network,
   ...tap,
+  ...path,
   constants,
   getKegGlobalConfig,
   findTask,

--- a/repos/cli-utils/src/network/__mocks__/getAddresses.js
+++ b/repos/cli-utils/src/network/__mocks__/getAddresses.js
@@ -11,7 +11,12 @@ const privateIPMock = {
 }
 
 module.exports = {
-  getAddresses: () => [ privateIPMock, publicIPMock ],
+  getAddresses: ({ isPrivate, isPublic }) => 
+    isPrivate 
+      ? [ privateIPMock ]
+      : isPublic
+        ? [ publicIPMock ]
+        : [ ],
   privateIPMock,
   publicIPMock,
 }

--- a/repos/cli-utils/src/network/__tests__/getAddresses.js
+++ b/repos/cli-utils/src/network/__tests__/getAddresses.js
@@ -18,8 +18,8 @@ describe('getAddresses', () => {
     })
 
     const addresses = getAddresses({
-      private: true,
-      public: false,
+      isPrivate: true,
+      isPublic: false,
       version: 4
     })
 

--- a/repos/cli-utils/src/network/getAddresses.js
+++ b/repos/cli-utils/src/network/getAddresses.js
@@ -12,26 +12,25 @@ const getIPVersion = familyStr => familyStr && parseInt(
 /**
  * Gets network addresses matching the filter parameters
  * @param {Object} options
- * @param {Boolean} options.private - if true, only get private ip addresses
- * @param {Boolean} options.public - if true, only get public ip addresses
- * @param {Object} options.interface - the interface to get addresses for
- * @param {Object} options.internal - whether or the ip address is internal or not
+ * @param {Boolean} options.isPrivate - if true, only get private ip addresses
+ * @param {Boolean} options.isPublic - if true, only get public ip addresses
+ * @param {Object} options.iface - the interface to get addresses for
  * @param {number | string} options.version - the ip version
  * @returns {Array} - array of matching addresses
  */
- const getAddresses = ({ interface='en0', private, public, version }) => {
+ const getAddresses = ({ iface='en0', isPrivate, isPublic, version }) => {
   const interfaces = networkInterfaces()
 
-  if (!interfaces[interface])
-    throw new Error(`Could not find interface ${interface} in network`)
+  if (!interfaces[iface])
+    throw new Error(`Could not find interface ${iface} in network`)
 
-  return interfaces[interface].filter(addr => {
+  return interfaces[iface].filter(addr => {
     const ipVersion = getIPVersion(addr.family)
-    const isPrivate = isPrivateIP(addr.address)
+    const ipIsPrivate = isPrivateIP(addr.address)
 
     return (!version || ipVersion === version)
-      && (!private || isPrivate)
-      && (!public || !isPrivate)
+      && (!isPrivate || ipIsPrivate)
+      && (!isPublic || !ipIsPrivate)
   })
 }
 

--- a/repos/cli-utils/src/network/getHostIP.js
+++ b/repos/cli-utils/src/network/getHostIP.js
@@ -9,12 +9,12 @@ const { mapFind } = require('@keg-hub/jsutils')
  * @returns {string} - Found host IP address
  */
 const getHostIP = () => {
-  const interfaces = os.networkInterfaces()
+  const ifaces = os.networkInterfaces()
 
   // pass over each interface to find the host address
   return mapFind(
-    interfaces, 
-    interface => mapFind(interface, addrInfo => {
+    ifaces, 
+    iface => mapFind(iface, addrInfo => {
       const { family, internal, address } = addrInfo
 
       // we may have the custom dns resolver running (see scripts/docker/dnsmasq)

--- a/repos/cli-utils/src/network/getPrivateIPs.js
+++ b/repos/cli-utils/src/network/getPrivateIPs.js
@@ -4,7 +4,7 @@ const { getAddresses } = require('./getAddresses')
  * @param {string} - (optional) the interface to check. Defaults to the wifi interface en0
  * @returns {Array<string>} the private ip addresses associated with the interface
  */
- const getPrivateIPs = (interface='en0') => getAddresses({ interface, private: true })
+ const getPrivateIPs = (interface='en0') => getAddresses({ interface, isPrivate: true })
    .map(addrInfo => addrInfo.address)
 
 module.exports = { getPrivateIPs }

--- a/repos/cli-utils/src/network/getPrivateIPs.js
+++ b/repos/cli-utils/src/network/getPrivateIPs.js
@@ -4,7 +4,7 @@ const { getAddresses } = require('./getAddresses')
  * @param {string} - (optional) the interface to check. Defaults to the wifi interface en0
  * @returns {Array<string>} the private ip addresses associated with the interface
  */
- const getPrivateIPs = (interface='en0') => getAddresses({ interface, isPrivate: true })
+ const getPrivateIPs = (iface='en0') => getAddresses({ iface, isPrivate: true })
    .map(addrInfo => addrInfo.address)
 
 module.exports = { getPrivateIPs }

--- a/repos/cli-utils/src/path/__tests__/getPackageRoot.js
+++ b/repos/cli-utils/src/path/__tests__/getPackageRoot.js
@@ -1,0 +1,21 @@
+jest.mock('@keg-hub/jsutils/src/node', () => ({
+  tryRequireSync: jest.fn()
+}))
+const { tryRequireSync } = require('@keg-hub/jsutils/src/node')
+const { getPackageRoot } = require('../')
+
+describe('getPackageRoot', () => {
+
+  it('should check all paths up to the root, then return null when nothing is found', () => {
+    tryRequireSync.mockReturnValue(null)
+    expect(getPackageRoot('my/test/file/path')).toBeNull()
+  })
+
+  it('should return the first ancestor path that has a package.json file', () => {
+    tryRequireSync.mockReturnValueOnce(null).mockReturnValueOnce({})
+    expect(getPackageRoot('my/test/file/path')).toEqual(
+      expect.stringMatching('.*my/test/file$')
+    )
+  })
+
+})

--- a/repos/cli-utils/src/path/getPackageRoot.js
+++ b/repos/cli-utils/src/path/getPackageRoot.js
@@ -1,0 +1,23 @@
+const { tryRequireSync } = require('@keg-hub/jsutils/src/node')
+const path = require('path')
+
+/**
+ * @param {string} location 
+ * @returns {string} - root package directory of a path located at `location`, or else null if none exists
+ */
+ const getPackageRoot = location => {
+  // base case at root directory
+  if (location === '/')
+    return null
+
+  // check if the current location is the app root
+  const nextPath = path.resolve(location, 'package.json')
+  if (tryRequireSync(nextPath))
+    return location
+
+  // otherwise recurse up
+  const parentPath = path.resolve(location, '..')
+  return getPackageRoot(parentPath)
+}
+
+module.exports = { getPackageRoot }

--- a/repos/cli-utils/src/path/index.js
+++ b/repos/cli-utils/src/path/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('./getPackageRoot')
+}

--- a/repos/cli-utils/src/tap/__tests__/getTapRoot.js
+++ b/repos/cli-utils/src/tap/__tests__/getTapRoot.js
@@ -1,0 +1,28 @@
+jest.mock('../../path/getPackageRoot', () => ({ getPackageRoot: jest.fn() }))
+jest.mock('../getTapPath', () => ({ getTapPath: jest.fn() }))
+const { getPackageRoot } = require('../../path/getPackageRoot')
+const { getTapRoot, getTapPath } = require('../')
+
+describe('getTapRoot', () => {
+
+  it('should just find the path root if its called with location', () => {
+    getPackageRoot.mockReturnValue('/foo')
+    const location = 'my/test/path'
+    const result = getTapRoot({ location })
+    expect(result).toEqual('/foo')
+  })
+
+  it('should get the tap path if called with tap alias', () => {
+    getTapPath.mockReturnValue('/foo')
+    const tap = 'my_tap'
+    const result = getTapRoot({ tap })
+    expect(result).toEqual('/foo')
+  })
+
+  it('should throw if required arguments are omitted', () => {
+    expect(
+      getTapRoot
+    ).toThrow()
+  })
+
+})

--- a/repos/cli-utils/src/tap/getTapRoot.js
+++ b/repos/cli-utils/src/tap/getTapRoot.js
@@ -1,0 +1,22 @@
+const { getTapPath } = require('./getTapPath')
+const { getPackageRoot } = require('../path/getPackageRoot')
+const { getKegGlobalConfig } = require('../task/getKegGlobalConfig')
+
+/**
+ * Finds the path to the a taps root folder based on passed in params
+ * Uses the global keg-cli config to find a taps path when tap param exists
+ * @param {Object} params - Options to help finding a taps root location
+ * @param {string} params.tap - Name of a linked tap in the global keg-cli config
+ * @param {string} params.location - Custom location of a tap ( Must be absolute )
+ * @returns {string} - Path on the host machine to a tap's root folder
+ */
+ const getTapRoot = ({ tap, location }={}) => {
+  if (!tap && !location)
+    throw new Error('Cannot resolve tap root without a tap alias or location string!', { tap, location })
+
+  return location
+    ? getPackageRoot(location)
+    : getTapPath(getKegGlobalConfig(), tap)
+}
+
+module.exports = { getTapRoot }

--- a/repos/cli-utils/src/tap/index.js
+++ b/repos/cli-utils/src/tap/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   ...require('./getTapConfig'),
-  ...require('./getTapPath')
+  ...require('./getTapPath'),
+  ...require('./getTapRoot')
 }


### PR DESCRIPTION
## Goal

* Move two utilities from `tap-snack` to `cli-utils`
  * migrated from [this PR](https://github.com/simpleviewinc/tap-snack/pull/5) as part of review feedback

## Updates
* `repos/cli-utils/src/path/getPackageRoot.js`
  * gets the root path of a package 
* `repos/cli-utils/src/tap/getTapRoot.js`
  * gets the root path of a tap
* `repos/cli-utils/src/network` 
  * I noticed some of these functions I wrote were using keywords that are reserved in strict-mode or will be reserved in the future, so I updated it to use non-reserved keywords

## Testing
* ensure tests pass
