### PR TITLE
parse-config: Remove keg global config requirement

### DIFF
--- a/repos/parse-config/package.json
+++ b/repos/parse-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keg-hub/parse-config",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Utils to allow loading non-javascript files into a node environment",
   "repository": "https://github.com/simpleviewinc/keg-cli/tree/master/repos/parse-config",
   "main": "index.js",

--- a/repos/parse-config/src/template/template.js
+++ b/repos/parse-config/src/template/template.js
@@ -36,11 +36,12 @@ const setTemplateRegex = pattern => {
  * Sources include Keg-CLI global config, process.env, custom data object argument
  * @function
  * @param {Object} data - Custom data with values for filling templates
+ * @param {Boolean} expectKegConfig - if true, throws if global keg config is not found
  *
  * @returns {Object} - Merge data object
  */
-const buildFillData = (data = noOpObj) => {
-  const globalConfig = getKegGlobalConfig() || noOpObj
+const buildFillData = (data = noOpObj, expectKegConfig=false) => {
+  const globalConfig = getKegGlobalConfig(expectKegConfig) || noOpObj
   // Add the globalConfig, and the process.envs as the data objects
   // This allows values in ENV templates from globalConfig || process.env
   return {


### PR DESCRIPTION
## Goal

* Fix an issue preventing `va-platform-backend` container from running
* The `va-platform-backend` container is using `parse-config`, which expects the keg global config, which is not in the container. We just need it to use an empty object in that case.

## Updates
* `repos/parse-config/src/template/template.js`
  * added a parameter to toggle the keg-config requirement

## Testing
* verify tests pass
