### PR TITLE
Mutagen list fix

### DIFF
--- a/repos/mutagen-lib/src/sync.js
+++ b/repos/mutagen-lib/src/sync.js
@@ -23,7 +23,7 @@ class Sync {
   * @param {string} args.format - Output format type ( text || json )
   * @param {boolean} args.log - Should the command being run be logged
   *
-  * @returns {*} - response local the mutagen CLI
+  * @returns {Array} - response local the mutagen CLI
   */
   list = async (args={}) => {
     const { opts=[] } = args

--- a/repos/mutagen-lib/src/sync.js
+++ b/repos/mutagen-lib/src/sync.js
@@ -32,7 +32,7 @@ class Sync {
       ...args,
       isList: true,
       opts: [ `sync`, `list` ].concat(opts),
-    })
+    }) || []
   }
 
   /**


### PR DESCRIPTION
**Ticket**: [VIS-1107](https://jira.simpleviewtools.com/browse/VIS-1107)

## Context
* Sometimes the `keg-boot` service technically "fails" on an EC2 instance when booting
  * it happens because the `mutagen-lib`'s `list` function returns undefined, right at boot. Something with mutagen isn't available at this time, so it causes exceptions to be thrown later in the call stack.
  * it doesn't actually break anything, though. The keg-boot service still ultimately runs correctly and starts the package with working mutagen syncs. But because this initial error was thrown, the `keg-boot` service was flagged as "failed" in `systemd`

## Goal

* Ensure the mutagen-lib `list` functions returns an empty array if no syncs are found, so that functions expecting an array don't throw errors

## Updates
* `repos/mutagen-lib/src/sync.js`
  * added an empty array as a fallback return value to the `list` function
  * I tested this on `keg-boot`
    * the syncs still work

## Testing

* I already tested this out on the `AMI Test 2` ec2 instance for dev visitapps. If you want, go ahead and reboot it again and see that it works as expected
  * the `keg-boot` service should successfully activate
  * the `vab` image should be started and its admin api accessible
