### PR TITLE
fix(node) Set node to v14.17 and fix recreate option

### DIFF
--- a/containers/base/defaults.env
+++ b/containers/base/defaults.env
@@ -31,7 +31,7 @@ EXPO_CLI_VERSION=4.10.0
 SHARP_CLI_VERSION=1.15.0
 
 # Version of Node to use for the keg-base:develop image
-KEG_NODE_VERSION=14.7-alpine
+KEG_NODE_VERSION=14.17-alpine
 
 # Name of the image used in the FROM directive of the Dockerfile
 KEG_IMAGE_FROM=ghcr.io/simpleviewinc/keg-base:{{cli.settings.docker.defaultTag}}

--- a/scripts/ci/ci.env
+++ b/scripts/ci/ci.env
@@ -22,7 +22,7 @@ EXPO_CLI_VERSION=4.10.0
 SHARP_CLI_VERSION=1.15.0
 
 # Name of the image used in the FROM directive of the Dockerfile
-KEG_NODE_VERSION=14.7-alpine
+KEG_NODE_VERSION=14.17-alpine
 
 # Container Ports
 EXPO_DEBUG_PORT=19002

--- a/scripts/cli/updates/5.2.1.sh
+++ b/scripts/cli/updates/5.2.1.sh
@@ -7,12 +7,12 @@ source $(pwd)/scripts/cli/updates/update_helpers.sh
 
 keg_cli_5_2_1_update(){
 
-  keg_message "Running update for version 5.1.0..."
+  keg_message "Running update for version 5.2.1..."
 
   keg cli env sync --conflict local --no-confirm
 
   echo ""
-  keg_message "5.1.0 Update Complete!"
+  keg_message "5.2.1 Update Complete!"
   echo ""
 
 }

--- a/scripts/cli/updates/5.2.1.sh
+++ b/scripts/cli/updates/5.2.1.sh
@@ -1,0 +1,20 @@
+
+#!/usr/bin/env
+
+source $(pwd)/keg
+
+source $(pwd)/scripts/cli/updates/update_helpers.sh
+
+keg_cli_5_2_1_update(){
+
+  keg_message "Running update for version 5.1.0..."
+
+  keg cli env sync --conflict local --no-confirm
+
+  echo ""
+  keg_message "5.1.0 Update Complete!"
+  echo ""
+
+}
+
+keg_cli_5_2_1_update "$@"

--- a/scripts/cli/updates/5.2.2.sh
+++ b/scripts/cli/updates/5.2.2.sh
@@ -5,16 +5,16 @@ source $(pwd)/keg
 
 source $(pwd)/scripts/cli/updates/update_helpers.sh
 
-keg_cli_5_2_1_update(){
+keg_cli_5_2_2_update(){
 
-  keg_message "Running update for version 5.2.1..."
+  keg_message "Running update for version 5.2.2..."
 
   keg cli env sync --conflict local --no-confirm
 
   echo ""
-  keg_message "5.2.1 Update Complete!"
+  keg_message "5.2.2 Update Complete!"
   echo ""
 
 }
 
-keg_cli_5_2_1_update "$@"
+keg_cli_5_2_2_update "$@"

--- a/scripts/setup/defaults.env
+++ b/scripts/setup/defaults.env
@@ -35,7 +35,7 @@ EXPO_CLI_VERSION=4.10.0
 SHARP_CLI_VERSION=1.15.0
 
 # Version of Node to use for the keg-base:develop image
-KEG_NODE_VERSION=14.7-alpine
+KEG_NODE_VERSION=14.17-alpine
 
 KEG_IMAGE_FROM=ghcr.io/simpleviewinc/keg-base:{{cli.settings.docker.defaultTag}}
 KEG_IMAGE_TAG={{ cli.settings.docker.defaultTag }}

--- a/src/__mocks__/injected/injectedTest.js
+++ b/src/__mocks__/injected/injectedTest.js
@@ -58,7 +58,7 @@ const injectedTest = {
     GIT_RESOLVER_URL: 'https://github.com/simpleviewinc/.git',
     GIT_PROXY_URL: 'https://github.com/simpleviewinc/.git',
     KEG_IMAGE_FROM: 'tap-injected-test:develop',
-    KEG_NODE_VERSION: '14.7-alpine',
+    KEG_NODE_VERSION: '14.17-alpine',
     DOC_CLI_PATH: '/keg/keg-cli',
     DOC_CORE_PATH: '/keg/tap/node_modules/keg-core',
     DOC_COMPONENTS_PATH: '/keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components',

--- a/src/utils/services/startService.js
+++ b/src/utils/services/startService.js
@@ -2,7 +2,7 @@ const { pullService } = require('./pullService')
 const { proxyService } = require('./proxyService')
 const { composeService } = require('./composeService')
 const { getServiceArgs } = require('./getServiceArgs')
-const { get, set, deepMerge } = require('@keg-hub/jsutils')
+const { get, set, deepMerge, exists } = require('@keg-hub/jsutils')
 const { checkEnvConstantValue } = require('KegUtils/helpers/checkEnvConstantValue')
 
 /**
@@ -42,12 +42,16 @@ const startService = async (args, exArgs) => {
   checkEnvConstantValue(cmdContext, 'KEG_AUTO_SYNC', false)
     && (internalOpts.skipDockerSyncs = true)
 
+  // Check if the recreate param was explicitly passed. If it was, then we use that
+  // Otherwise use the isNewImage value
+  const recreate = get(args, `params.recreate`)
+
   // Call the compose service to start the application
   // Pass in recreate, base on if a new image was pulled
   // Set 'pull' param to false, because we already did that above
   return await composeService(deepMerge(serviceArgs, {
     __internal: internalOpts,
-    params: { pull: false, recreate: isNewImage },
+    params: { pull: false, recreate: exists(recreate) ? recreate : isNewImage },
   }))
 
 }

--- a/src/utils/task/options/startServiceOptions.js
+++ b/src/utils/task/options/startServiceOptions.js
@@ -72,7 +72,6 @@ const startServiceOptions = (task='', action='') => {
       alias: [ 'rec', `create` ],
       description: 'Force recreate all the docker containers for the tap service',
       example: 'keg ${ task } ${ action } --recreate',
-      default: false
     },
     sync: {
       alias: [ 'syncs', 'sy' ],


### PR DESCRIPTION
## Goal

* Fix Node Version
  * The `5.2.0` update script and the defaults had the node version set to `14.7`
  * This should have been `14.17`
  * The update was from `14.16` up to `14.17`, but instead it down graded to `14.7` 
  * These change fix that by setting the correct node version, which is `14.17`
* Fix Recreate
  * This option was being ignored in the start service
  * This update adds a check to see if it exists, then uses it when it does
  * If recreate does not exist, then is uses the `isNewImage` variable
    * If `isNewImage` === `true`, then a new image is created
    * Else it reuses the same image as before

## Updates
* `containers/base/**` && `scripts/**`
  * Update the node version to `14.17-alpine`
* `src/utils/services/startService.js`
  * Check the params for the `recreate` option
    * Ensure that value is used over the response from the `pullService` when it exists
* `src/utils/task/options/startServiceOptions.js`
  * Removed defaulting the `recreate` option to `false`
    * This allows checking if it exists, and if it does then use it.
    * Otherwise, we skip it entirely

## Testing
> Not sure how but updating to node-14-17 is causing the SVG Icons to do odd things
> This is probably related to keg-components updates is some way
> Honestly I was surprized when everything just worked, so in some ways I'm glad this showed up
> I'm planning to create a ticket in jira for the issue. regardless these updates are needed
> So I don't see it as a blocker for these changes

### Test 1
* Pull these changes =>  `keg pr 118`
* Run the update script =>  `keg cli update --version 5.2.2`
  * This script should update your Defaults.envs Node version to `14.17-alpine`
* To confirm the update
  * Open your global config => `keg config open`
  * Then open your `defaults.env` file
  * Find the `KEG_NODE_VERSION` ENV, and ensure it's value is `14.17-alpine`

### Test 2
* Run the command `keg cli test --jest`
  * Ensure all tests pass

### Test 3
* Run the cmd `keg evf pack run evf:test-node-v-14-17`
* Then navigate your browser the [evf tap](http://evf-test-node-v-14-17.local.keghub.io)
* Ensure it works as expected
  * I know the Icons are messed up, but that's a separate problem that will need to be fixed in keg-components or the tap

### Test 4
* Run the cmd `keg evf start`
  * This should start the `events-force` tap
* Open another terminal window, and run cmd `keg dc`
  * Find the container id for the running `events-force` tap
  * Write it down somewhere so we can compare it later
* Run the cmd `keg evf start` again
  * This should again start the `events-force` tap, but it should reuse the same container
  * At some point it should show a warning that the `1900` port is already being used
    * [Looks like this](https://i.imgur.com/QfBhVH1.png)
    * You can also run cmd `keg dc` again and 
      * Validate that the container ID is the same as before
      * No other evf containers were started
* Hit `ctrl+c` to exit the evf container
* Then run the cmd `keg evf start --recreate`
  * It should try to start the `events-force` tap again
  * But, because the `--recreate` option is also passed, if should recreate the docker container
    * [Looks like this](https://i.imgur.com/pNyQNIs.png)
  * Run the cmd `keg dc`, and validate that the containers have a new container ID
