### PR TITLE
Updated Tap Print

### DIFF
--- a/src/tasks/tap/print.js
+++ b/src/tasks/tap/print.js
@@ -32,13 +32,11 @@ const packageNames = [ 'package', 'pkg', 'p']
  * @throws {Error}
  */ 
 const throwMissingConfigError = (tap, searchPath) => {
-  const reason = tap
-    ? `Expected path parameter to start with one of: [${configNames.toString()}] or [${packageNames.toString()}]`
-    : 'Verify your current path is a linked tap.\n'
-
   generalError(`
-    Could not find object to print from search path "${searchPath}"
-    ${reason}
+    Could not find object to print with search path "${searchPath}"
+    Verify that:
+      - Your search path parameter starts with one of: [${configNames.toString()}] or [${packageNames.toString()}] (default='config')
+      ${ !tap ? '- Your current path is a linked tap.' : '' }
   `)
 }
 

--- a/src/tasks/tap/print.js
+++ b/src/tasks/tap/print.js
@@ -25,28 +25,42 @@ const configNames = [ 'config', 'cfg', 'c' ]
 // accepted names for the package.json
 const packageNames = [ 'package', 'pkg', 'p']
 
+/** 
+ * Helper for printConfig when it cannot find a config to print
+ * @param {string} tap - tap alias
+ * @param {string} searchPath - config or package search path
+ * @throws {Error}
+ */ 
+const throwMissingConfigError = (tap, searchPath) => {
+  const reason = tap
+    ? `Expected path parameter to start with one of: [${configNames.toString()}] or [${packageNames.toString()}]`
+    : 'Verify your current path is a linked tap.\n'
+
+  generalError(`
+    Could not find object to print from search path "${searchPath}"
+    ${reason}
+  `)
+}
+
 /**
- * Prints out a tap's config or package.json (see options)
+ * Prints out a tap's config or package.json (see options), using the specified tap or the tap in your current directory  
  * @param {Object} args - arguments passed from the runTask method
  */
 const printConfig = args => {
   const { params } = args
   const { tap, path, verbose } = params
 
-  !tap && generalError('Cannot print config without a tap parameter.')
+  // find tap using these parameters
+  const searchParams = { name: tap, path: !tap && process.cwd() }
 
   const [ fileType, subPath ] = splitPath(path)
   const [ config, foundPath ] = configNames.includes(fileType)
-    ? getTapConfig({ name: tap })
+    ? getTapConfig(searchParams)
     : packageNames.includes(fileType)
-      ? getTapPackage({ name: tap })
+      ? getTapPackage(searchParams)
       : []
 
-  !config && 
-    generalError(`
-      Could not find object to print from path "${path}". 
-      Expected path to start with one of: [${configNames.toString()}] or [${packageNames.toString()}]
-    `)
+  !config && throwMissingConfigError(tap, path)
 
   const value = get(config, subPath, config)
 
@@ -65,8 +79,9 @@ module.exports = {
   print: {
     name: 'print',
     action: printConfig,
-    description: `Prints out the tap config or package json`,
+    description: `Prints out the tap config or package json, using the specified tap or the tap in your current directory`,
     alias: ['prnt', 'prn'],
+    example: 'keg tap print config.keg.alias',
     options: {
       path: {
         description: 'Optional path to a value within the config you want to read. Needs to start with either "config" for the tap config or "package" for package.json',


### PR DESCRIPTION
## Context
* I'm working on some small updates to keg-herkin, and I wanted a way to get the alias of a tap given only its file system path
  * this is so we can generate a keg url, e.g. `http://evf-develop.local.keg-hub.io`
* There already exists a utility for getting tap info by alias, so I decided to update it to also check the current directory if the alias isn't specified

## Updates

* `src/tasks/tap/print.js`
  * updated to work with current directory, e.g. `keg evf && keg tap print config.keg.alias` 

## Testing
* `keg cli && keg pr 127`
* `keg evf && keg tap print config.keg.alias`
  * verify it prints out `evf`
* `keg evf print config.keg.alias`
  * verify it prints out `evf` again
* Move to a directory that isn't a tap and run `keg tap print`
  * verify the error message asks you to verify that your current path is a linked tap
